### PR TITLE
update test tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 *.a
 pw
+pwcheck
 go-auth.h
 
 # Test binary, build with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all:
 	go build -buildmode=c-archive go-auth.go
 	go build -buildmode=c-shared -o go-auth.so
 	go build pw-gen/pw.go
+	go build pw-gen/pwcheck.go
 
 requirements:
 	dep ensure -v

--- a/pw-gen/pw.go
+++ b/pw-gen/pw.go
@@ -7,18 +7,16 @@ import (
 	"github.com/iegomez/mosquitto-go-auth/common"
 )
 
-// saltSize defines the salt size
-const saltSize = 16
-
 func main() {
 
 	var algorithm = flag.String("a", "sha512", "algorithm (sha256 or default: sha512)")
 	var HashIterations = flag.Int("i", 100000, "hash iterations (default: 100000)")
+	var saltSize = flag.Int("s", 16, "salt size (default: 16)")
 	var password = flag.String("p", "", "password")
 
 	flag.Parse()
 
-	pwHash, err := common.Hash(*password, saltSize, *HashIterations, *algorithm)
+	pwHash, err := common.Hash(*password, *saltSize, *HashIterations, *algorithm)
 	if err != nil {
 		fmt.Errorf("error: %s\n", err)
 	} else {

--- a/pw-gen/pwcheck.go
+++ b/pw-gen/pwcheck.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/iegomez/mosquitto-go-auth/common"
+)
+
+// saltSize defines the salt size
+
+func main() {
+
+	var pkdf2 = flag.String("h", "", "pbkdf2 password hash")
+	var password = flag.String("p", "", "password to compare with")
+
+	flag.Parse()
+
+	isEqual := common.HashCompare(*password, *pkdf2)
+	if (isEqual) {
+		fmt.Println("True")
+	} else {
+		fmt.Println("False")
+        os.Exit(1)
+	}
+}

--- a/pw-gen/pwcheck.go
+++ b/pw-gen/pwcheck.go
@@ -8,20 +8,17 @@ import (
 	"github.com/iegomez/mosquitto-go-auth/common"
 )
 
-// saltSize defines the salt size
-
 func main() {
 
-	var pkdf2 = flag.String("h", "", "pbkdf2 password hash")
-	var password = flag.String("p", "", "password to compare with")
+	var password = flag.String("p", "", "plain text password")
+	var hashed = flag.String("h", "", "pbkdf2 password hash")
 
 	flag.Parse()
 
-	isEqual := common.HashCompare(*password, *pkdf2)
-	if (isEqual) {
-		fmt.Println("True")
-	} else {
-		fmt.Println("False")
-        os.Exit(1)
+	if (common.HashCompare(*password, *hashed)) {
+		fmt.Println("success: plain and hashed passwords match")
+        return
 	}
+	fmt.Println("error: plain and hashed passwords don't match")
+    os.Exit(1)
 }


### PR DESCRIPTION
for easier comparison of pbkdf2 hash i added a new commad line tool using your library functions.
Hope it helps or may be usefull in it self for some shell scripting

* add cli tool to compare password with pbkdf2 hash
* allow setting keylwght on generating new hash with pw cli tool