### PR TITLE
Pr for #43, add mongodb option to specify AuthSource database name

### DIFF
--- a/backends/mongo.go
+++ b/backends/mongo.go
@@ -23,6 +23,7 @@ type Mongo struct {
 	Username        string
 	Password        string
 	DBName          string
+	AuthSource		string
 	UsersCollection string
 	AclsCollection  string
 	Conn            *mongo.Client
@@ -50,6 +51,7 @@ func NewMongo(authOpts map[string]string, logLevel log.Level) (Mongo, error) {
 		Username:        "",
 		Password:        "",
 		DBName:          "mosquitto",
+		AuthSource:		 "",
 		UsersCollection: "users",
 		AclsCollection:  "acls",
 	}
@@ -74,6 +76,10 @@ func NewMongo(authOpts map[string]string, logLevel log.Level) (Mongo, error) {
 		m.DBName = mongoDBName
 	}
 
+	if mongoAuthSource, ok := authOpts["mongo_authsource"]; ok {
+		m.AuthSource = mongoAuthSource
+	}
+
 	if usersCollection, ok := authOpts["mongo_users"]; ok {
 		m.UsersCollection = usersCollection
 	}
@@ -92,11 +98,21 @@ func NewMongo(authOpts map[string]string, logLevel log.Level) (Mongo, error) {
 	opts.ApplyURI(addr)
 
 	if m.Username != "" && m.Password != "" {
-		opts.Auth = &options.Credential{
-			AuthSource:  m.DBName,
-			Username:    m.Username,
-			Password:    m.Password,
-			PasswordSet: true,
+		if m.AuthSource != "" {
+			opts.Auth = &options.Credential{
+				AuthSource:  m.AuthSource,
+				Username:    m.Username,
+				Password:    m.Password,
+				PasswordSet: true,
+			}
+		}
+		else {
+			opts.Auth = &options.Credential{
+				AuthSource:  m.DBName,
+				Username:    m.Username,
+				Password:    m.Password,
+				PasswordSet: true,
+			}
 		}
 	}
 

--- a/backends/mongo.go
+++ b/backends/mongo.go
@@ -23,7 +23,7 @@ type Mongo struct {
 	Username        string
 	Password        string
 	DBName          string
-	AuthSource		string
+	AuthSource      string
 	UsersCollection string
 	AclsCollection  string
 	Conn            *mongo.Client
@@ -51,7 +51,7 @@ func NewMongo(authOpts map[string]string, logLevel log.Level) (Mongo, error) {
 		Username:        "",
 		Password:        "",
 		DBName:          "mosquitto",
-		AuthSource:		 "",
+		AuthSource:	     "",
 		UsersCollection: "users",
 		AclsCollection:  "acls",
 	}

--- a/backends/mongo.go
+++ b/backends/mongo.go
@@ -105,8 +105,7 @@ func NewMongo(authOpts map[string]string, logLevel log.Level) (Mongo, error) {
 				Password:    m.Password,
 				PasswordSet: true,
 			}
-		}
-		else {
+		} else {
 			opts.Auth = &options.Credential{
 				AuthSource:  m.DBName,
 				Username:    m.Username,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,8 @@ FROM debian:stable-slim as builder
 
 #Set mosquitto and plugin versions.
 #Change them for your needs.
-ENV MOSQUITTO_VERSION=1.6.3
-ENV PLUGIN_VERSION=0.5.0
-ENV GO_VERSION=1.12.6
+ENV MOSQUITTO_VERSION=1.6.8
+ENV GO_VERSION=1.13.6
 
 WORKDIR /app
 
@@ -24,15 +23,14 @@ RUN cd mosquitto-${MOSQUITTO_VERSION} && make WITH_WEBSOCKETS=yes && make instal
 RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 RUN export PATH=$PATH:/usr/local/go/bin && go version && rm go${GO_VERSION}.linux-amd64.tar.gz
 
-#Get the plugin.
-RUN wget https://github.com/iegomez/mosquitto-go-auth/archive/${PLUGIN_VERSION}.tar.gz \
-    && ls -l \
-    && tar xvf *.tar.gz --strip-components=1 \
-    && rm -Rf go*.tar.gz \
-    && ls -l
-
-#Build the plugin.
-RUN export PATH=$PATH:/usr/local/go/bin && export CGO_CFLAGS="-I/usr/local/include -fPIC" && export CGO_LDFLAGS="-shared" &&  make
+#Get / build the plugin.
+RUN mkdir mosquitto-go-auth && \
+    cd mosquitto-go-auth && \
+    git clone https://github.com/iegomez/mosquitto-go-auth.git . && \
+    export PATH=$PATH:/usr/local/go/bin && \
+    export CGO_CFLAGS="-I/usr/local/include -fPIC" && \
+    export CGO_LDFLAGS="-shared" && \
+    make
 
 #Start from a new image.
 FROM debian:stable-slim
@@ -49,7 +47,8 @@ RUN groupadd mosquitto \
 
 #Copy confs, plugin so and mosquitto binary.
 COPY --from=builder /app/mosquitto/ /mosquitto/
-COPY --from=builder /app/go-auth.so /mosquitto/go-auth.so
+COPY --from=builder /app/mosquitto-go-auth/pw /mosquitto/pw
+COPY --from=builder /app/mosquitto-go-auth/go-auth.so /mosquitto/go-auth.so
 COPY --from=builder /usr/local/sbin/mosquitto /usr/sbin/mosquitto
 
 #Uncomment to copy your custom confs (change accordingly) directly when building the image.


### PR DESCRIPTION
As per #43, this PR adds AuthSource, default value `""`, and creates IFTE so that:
* if specified AuthSource option (DB name) is supplied, use this in opts.Auth
* else, AuthSource follows original behavior, using DBName in opts.Auth

Also updated Docker file:
* Go version
* Mosquitto version
* Change build process to pull source from github, and package files did not appear to be up-to-date