### PR TITLE
JWT validate only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+
+#Use debian:stable-slim as a builder and then copy everything.
+FROM debian:stable-slim as builder
+
+#Set mosquitto and plugin versions.
+#Change them for your needs.
+ENV MOSQUITTO_VERSION=1.6.3
+ENV PLUGIN_VERSION=0.5.0
+ENV GO_VERSION=1.12.6
+
+WORKDIR /app
+
+#Get mosquitto build dependencies.
+RUN apt-get update && apt-get install -y libwebsockets8 libwebsockets-dev libc-ares2 libc-ares-dev openssl uuid uuid-dev wget build-essential git
+RUN mkdir -p mosquitto/auth mosquitto/conf.d
+
+RUN wget http://mosquitto.org/files/source/mosquitto-${MOSQUITTO_VERSION}.tar.gz
+RUN tar xzvf mosquitto-${MOSQUITTO_VERSION}.tar.gz && rm mosquitto-${MOSQUITTO_VERSION}.tar.gz 
+
+#Build mosquitto.
+RUN cd mosquitto-${MOSQUITTO_VERSION} && make WITH_WEBSOCKETS=yes && make install && cd ..
+
+#Get Go.
+RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+RUN export PATH=$PATH:/usr/local/go/bin && go version && rm go${GO_VERSION}.linux-amd64.tar.gz
+
+
+# #Get the plugin.
+# RUN wget https://github.com/iegomez/mosquitto-go-auth/archive/${PLUGIN_VERSION}.tar.gz \
+#     && ls -l \
+#     && tar xvf *.tar.gz --strip-components=1 \
+#     && rm -Rf go*.tar.gz \
+#     && ls -l
+
+#Build the plugin from local source
+COPY ./ ./
+
+#Build the plugin.
+RUN export PATH=$PATH:/usr/local/go/bin && export CGO_CFLAGS="-I/usr/local/include -fPIC" && export CGO_LDFLAGS="-shared" &&  make
+
+#Start from a new image.
+FROM debian:stable-slim
+
+#Get mosquitto dependencies.
+RUN apt-get update && apt-get install -y libwebsockets8 libc-ares2 openssl uuid
+
+#Setup mosquitto env.
+RUN mkdir -p /var/lib/mosquitto /var/log/mosquitto 
+RUN groupadd mosquitto \
+    && useradd -s /sbin/nologin mosquitto -g mosquitto -d /var/lib/mosquitto \
+    && chown -R mosquitto:mosquitto /var/log/mosquitto/ \
+    && chown -R mosquitto:mosquitto /var/lib/mosquitto/
+
+#Copy confs, plugin so and mosquitto binary.
+COPY --from=builder /app/mosquitto/ /mosquitto/
+COPY --from=builder /app/go-auth.so /mosquitto/go-auth.so
+COPY --from=builder /usr/local/sbin/mosquitto /usr/sbin/mosquitto
+
+#Uncomment to copy your custom confs (change accordingly) directly when building the image.
+#Leave commented if you want to mount a volume for these (see docker-compose.yml).
+
+COPY ./docker/conf/mosquitto.conf /etc/mosquitto/mosquitto.conf
+COPY ./docker/conf/conf.d/go-auth.conf /etc/mosquitto/conf.d/go-auth.conf
+COPY ./docker/conf/auth/acls /etc/mosquitto/auth/acls
+COPY ./docker/conf/auth/passwords /etc/mosquitto/auth/passwords
+
+#Expose tcp and websocket ports as defined at mosquitto.conf (change accordingly).
+EXPOSE 1883 1884
+
+ENTRYPOINT ["sh", "-c", "/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf" ]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Please open an issue with the `feature` or `enhancement` tag to request new back
 	- [Testing SQLite3](#testing-sqlite3)
 - [JWT](#jwt)
 	- [Remote mode](#remote-mode)
-	- [Local mode](#local-mode)
+	- [Local mode - Validation](#local-mode---jwt-validation)
+	- [Local mode - Database](#local-mode---database)
 	- [Testing JWT](#testing-jwt)
 - [HTTP](#http)
 	- [Response mode](#response-mode)
@@ -710,7 +711,7 @@ initMqttClient(applicationID, mode, devEUI) {
   }
 ```
 
-#### Local mode - Token validation only
+#### Local mode - JWT Validation
 
 If you want to simply [validate](https://pkg.go.dev/github.com/dgrijalva/jwt-go?tab=doc#StandardClaims.Valid) the supplied JWT use the following options. 
 
@@ -723,7 +724,7 @@ If you want to simply [validate](https://pkg.go.dev/github.com/dgrijalva/jwt-go?
 | jwt_secret 		|				    |      Y      | JWT secret to check tokens | 
 
 
-#### Local mode - Database support
+#### Local mode - Database
 
 *Update: this backend will assume that the username is contained on StandardClaim's Subject field unless told otherwise with the option jwt_userfield. The alternative (which works with loraserver) is to set it to Username.*
 
@@ -798,7 +799,6 @@ When option jwt_aclquery is not present, AclCheck will always return true, hence
 #### Testing JWT
 
 This backend expects the same test DBs from the Postgres and Mysql test suites.
-
 
 
 ### HTTP

--- a/README.md
+++ b/README.md
@@ -710,8 +710,20 @@ initMqttClient(applicationID, mode, devEUI) {
   }
 ```
 
+#### Local mode - Token validation only
 
-#### Local mode
+If you want to simply [validate](https://pkg.go.dev/github.com/dgrijalva/jwt-go?tab=doc#StandardClaims.Valid) the supplied JWT use the following options. 
+
+>This method does not perform any user level checks, all users are considered "Super" users.
+
+| Option            | default           |  Mandatory  | Meaning     |
+| ----------------- | ----------------- | :---------: | ----------  |
+| jwt_remote 	    |  false			| 	   Y	  | Use Local Only             |
+| jwt_validate_only |  true			    |      Y	  | JWT is validated only      |
+| jwt_secret 		|				    |      Y      | JWT secret to check tokens | 
+
+
+#### Local mode - Database support
 
 *Update: this backend will assume that the username is contained on StandardClaim's Subject field unless told otherwise with the option jwt_userfield. The alternative (which works with loraserver) is to set it to Username.*
 
@@ -1137,8 +1149,10 @@ See the official [MQTT authentication & authorization guide](https://www.loraser
 
 ### Docker
 
-See the [docker](docker/) dir for an example image.
+If you want to build the container using:
 
+- Local plug-in source, use the Dockerfile in the root directory. 
+- Released plugin, see the [docker](docker/) dir for an example image.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ There are no requirements, as the tests create (and later delete) the DB and tab
 
 ### JWT
 
-The `jwt` backend is for auth with a JWT remote API or a local DB. The option jwt_remote sets the nature of the plugin:
+The `jwt` backend is for auth with a JWT remote API, local DB or token validation. The option jwt_remote sets the nature of the plugin:
 
 ```
 auth_opt_jwt_remote true
@@ -714,11 +714,11 @@ initMqttClient(applicationID, mode, devEUI) {
 
 If you want to simply [validate](https://pkg.go.dev/github.com/dgrijalva/jwt-go?tab=doc#StandardClaims.Valid) the supplied JWT use the following options. 
 
->This method does not perform any user level checks, all users are considered "Super" users.
+>This method does not perform any user access checks, all users are considered "Super" users.
 
 | Option            | default           |  Mandatory  | Meaning     |
 | ----------------- | ----------------- | :---------: | ----------  |
-| jwt_remote 	    |  false			| 	   Y	  | Use Local Only             |
+| jwt_remote 	    |  false			| 	   Y	  | Remote mode disabled       |
 | jwt_validate_only |  true			    |      Y	  | JWT is validated only      |
 | jwt_secret 		|				    |      Y      | JWT secret to check tokens | 
 

--- a/backends/jwt_test.go
+++ b/backends/jwt_test.go
@@ -46,6 +46,43 @@ var wrongJwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 	"username": "wrong_user",
 })
 
+func TestLocalValidationJWT(t *testing.T) {
+	Convey("Supplying an invalid token should return a nil error", t, func() {
+		token, err := jwtToken.SignedString([]byte(jwtSecret))
+		So(err, ShouldBeNil)
+
+		//Initialize JWT in local mode.
+		authOpts := make(map[string]string)
+		authOpts["jwt_remote"] = "false"
+		authOpts["jwt_secret"] = jwtSecret
+		authOpts["jwt_validate_only"] = "true"
+
+		Convey("Given correct option NewJWT returns an instance of jwt backend", func() {
+			jwt, err := NewJWT(authOpts, log.DebugLevel)
+			So(err, ShouldBeNil)
+
+			Convey("Given a correct token, it should correctly authenticate it", func() {
+
+				authenticated := jwt.GetUser(token, "")
+				So(authenticated, ShouldBeTrue)
+
+			})
+
+			Convey("Given an incorrect token, it should not authenticate it", func() {
+
+				wrongToken, err := wrongJwtToken.SignedString([]byte(jwtSecret))
+				So(err, ShouldBeNil)
+
+				authenticated := jwt.GetUser(wrongToken, "")
+				So(authenticated, ShouldBeFalse)
+
+			})
+
+			jwt.Halt()
+		})
+	})
+}
+
 func TestLocalPostgresJWT(t *testing.T) {
 
 	Convey("Creating a token should return a nil error", t, func() {


### PR DESCRIPTION
@iegomez , I found myself simply wanting to validate a JWT token locally and was unable to accomplish that using the existing options.

This PR adds support for simple JWT validation against the supplied `jwt_secret`. At this point it does not perform any other ACL or Super/User checks. (they all return `true`)

Although, I think it would be pretty neat to use the existing `jwt_*query` options to check the "claims"  against the files to determine if the token bearer has access.

Additionally, I've included a `Dockerfile` that will allow you to build the plugin from your local source instead of pulling down the released source. I had to move this out to the root directory because `docker build` will not let you traverse outside of it's pwd (e.g. `../`). I included a note in the Docker part of the readme.

I hope you will consider merging this PR -- if I need to update or clean up anything, please let me know.

