### PR TITLE
Docker Local Source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM debian:stable-slim as builder
 
 #Set mosquitto and plugin versions.
 #Change them for your needs.
-ENV MOSQUITTO_VERSION=1.6.3
+ENV MOSQUITTO_VERSION=1.6.8
 ENV PLUGIN_VERSION=0.6.1
-ENV GO_VERSION=1.12.6
+ENV GO_VERSION=1.13.8
 
 WORKDIR /app
 
@@ -23,14 +23,6 @@ RUN cd mosquitto-${MOSQUITTO_VERSION} && make WITH_WEBSOCKETS=yes && make instal
 #Get Go.
 RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 RUN export PATH=$PATH:/usr/local/go/bin && go version && rm go${GO_VERSION}.linux-amd64.tar.gz
-
-
-# #Get the plugin.
-# RUN wget https://github.com/iegomez/mosquitto-go-auth/archive/${PLUGIN_VERSION}.tar.gz \
-#     && ls -l \
-#     && tar xvf *.tar.gz --strip-components=1 \
-#     && rm -Rf go*.tar.gz \
-#     && ls -l
 
 #Build the plugin from local source
 COPY ./ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,16 @@ RUN cd mosquitto-${MOSQUITTO_VERSION} && make WITH_WEBSOCKETS=yes && make instal
 RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 RUN export PATH=$PATH:/usr/local/go/bin && go version && rm go${GO_VERSION}.linux-amd64.tar.gz
 
-#Get the plugin.
-RUN wget https://github.com/iegomez/mosquitto-go-auth/archive/${PLUGIN_VERSION}.tar.gz \
-    && ls -l \
-    && tar xvf *.tar.gz --strip-components=1 \
-    && rm -Rf go*.tar.gz \
-    && ls -l
+
+# #Get the plugin.
+# RUN wget https://github.com/iegomez/mosquitto-go-auth/archive/${PLUGIN_VERSION}.tar.gz \
+#     && ls -l \
+#     && tar xvf *.tar.gz --strip-components=1 \
+#     && rm -Rf go*.tar.gz \
+#     && ls -l
+
+#Build the plugin from local source
+COPY ./ ./
 
 #Build the plugin.
 RUN export PATH=$PATH:/usr/local/go/bin && export CGO_CFLAGS="-I/usr/local/include -fPIC" && export CGO_LDFLAGS="-shared" &&  make
@@ -55,10 +59,10 @@ COPY --from=builder /usr/local/sbin/mosquitto /usr/sbin/mosquitto
 #Uncomment to copy your custom confs (change accordingly) directly when building the image.
 #Leave commented if you want to mount a volume for these (see docker-compose.yml).
 
-#COPY conf/mosquitto.conf /etc/mosquitto/mosquitto.conf
-#COPY conf/conf.d/go-auth.conf /etc/mosquitto/conf.d/go-auth.conf
-#COPY conf/auth/acls /etc/mosquitto/auth/acls
-#COPY conf/auth/passwords /etc/mosquitto/auth/passwords
+# COPY ./docker/conf/mosquitto.conf /etc/mosquitto/mosquitto.conf
+# COPY ./docker/conf/conf.d/go-auth.conf /etc/mosquitto/conf.d/go-auth.conf
+# COPY ./docker/conf/auth/acls /etc/mosquitto/auth/acls
+# COPY ./docker/conf/auth/passwords /etc/mosquitto/auth/passwords
 
 #Expose tcp and websocket ports as defined at mosquitto.conf (change accordingly).
 EXPOSE 1883 1884

--- a/README.md
+++ b/README.md
@@ -1137,8 +1137,9 @@ See the official [MQTT authentication & authorization guide](https://www.loraser
 
 ### Docker
 
-See the [docker](docker/) dir for an example image.
+This project provides example Dockerfiles for building a Docker container that contains `mosquitto` and the `mosquitto-go-auth` plug-in.
 
+Please read the [documentation](./docker/README.md) in the [docker](/docker) directory for more information.
 
 ### License
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,9 @@ FROM debian:stable-slim as builder
 
 #Set mosquitto and plugin versions.
 #Change them for your needs.
-ENV MOSQUITTO_VERSION=1.6.3
+ENV MOSQUITTO_VERSION=1.6.8
 ENV PLUGIN_VERSION=0.6.1
-ENV GO_VERSION=1.12.6
+ENV GO_VERSION=1.13.8
 
 WORKDIR /app
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,11 @@
 ## Docker Images
 
-This project offers two seperate images for building the plug-in using either released or local source code.
+This project utilizes two `Dockerfiles` to give the option of building the `mosquitto-go-auth` plugin from either local or released source.
+
+In both cases the resulting image contains a compiled and ready to run version of `mosquitto` with the `mosquitto-go-auth` plugin-in enabled.
 
 ### Base Image
-Since there are several issues with using `alpine` based images we are using `debian:stable-slim` for both our build and final image. The final image size is about 113 MB.
+Since there are several issues with using `alpine` based images we are using `debian:stable-slim` for both our build and final image. The final image size is about 128 MB.
 
 Documented issues: 
 - https://github.com/iegomez/mosquitto-go-auth/issues/14
@@ -27,7 +29,37 @@ Both Dockerfiles compile `mosquitto` using the source code from the version spec
 >Mosquitto released versions can be found at https://mosquitto.org/files/source/
 
 #### Conf files
-The Dockerfiles will also copy `conf` files found in the `/docker/conf` directory. For your safety we have commented these instructions out, so you will have to uncomment the instructions for the files to be copied.
+The Dockerfiles can also copy `conf` files found in the `/docker/conf` project directory. 
+
+>You will have to uncomment the instructions manually for the files to be copied.
+
+
+### Docker Commands
+
+In case you're not familiar with [Docker](https://docs.docker.com/), here are some basic commands for getting going.
+
+Build Container:
+```sh
+# Ensure your PWD is either project root or /docker
+docker build -t mosquitto-go-auth .
+```
+
+Run Container:
+```sh
+# This command will run the container and map the corresponding ports locally.
+# You can access Mosquitto running inside the container on localhost:1883 and localhost:1884 (WebSockets)
+docker run -it -p 1884:1884 -p 1883:1883 mosquitto-go-auth 
+```
+
+Stop Container:
+```sh
+docker stop $(docker ps -q --filter ancestor=mosquitto-go-auth)
+```
+
+Remove Container locally:
+```sh
+docker rmi $(docker images -q --filter reference='mosquitto-go-auth:*')
+```
 
 ### Docker Compose
 This is just a working example of how a docker image could be built for this project and composed with other images such as a `redis` one for cache (check [docker-compose](docker-compose.yml)). Any contributions to make it better are very welcome.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,34 @@
-### Docker image
+## Docker Images
 
-This is an attempt on building a *not so heavy* image given the impossibility of using `alpine` based ones (see https://github.com/iegomez/mosquitto-go-auth/issues/14, https://github.com/iegomez/mosquitto-go-auth/issues/15 and https://github.com/iegomez/mosquitto-go-auth/issues/20).  
+This project offers two seperate images for building the plug-in using either released or local source code.
 
-It uses an intermediate image based on `debian:stable-slim` to build both mosquitto and the plugin and later on copies the binaries to the final image, also absed in `debian:stable-slim`, which stands at 113 MB.  
+### Base Image
+Since there are several issues with using `alpine` based images we are using `debian:stable-slim` for both our build and final image. The final image size is about 113 MB.
 
-The example `Dockerfile` will also copy `conf` files present at the current dir as well as set the versions for Go, mosquitto and the plugin. Please change values as needed.
+Documented issues: 
+- https://github.com/iegomez/mosquitto-go-auth/issues/14
+- https://github.com/iegomez/mosquitto-go-auth/issues/15
+- https://github.com/iegomez/mosquitto-go-auth/issues/20 
 
+### Build method
+The Dockerfiles utilize the [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) build feature provided by the Docker CLI.
+
+This feature allows you to optimize the final image output by copying select artifacts from the previous stage.
+
+### mosquitto-go-auth Plug-in (Released Source)
+The `Dockerfile` in the `/docker` directory compiles the plug-in using the specified `PLUGIN_VERSION` source code. The source code will come directly from our [GitHub Releases](https://github.com/iegomez/mosquitto-go-auth/releases).
+
+### mosquitto-go-auth Plug-In (Local Source)
+The `Dockerfile` located in the `root` (`/`) directory will compile the plug-in using your local source code.
+
+### Mosquitto
+Both Dockerfiles compile `mosquitto` using the source code from the version specified by `MOSQUITTO_VERSION`. 
+
+>Mosquitto released versions can be found at https://mosquitto.org/files/source/
+
+#### Conf files
+The Dockerfiles will also copy `conf` files found in the `/docker/conf` directory. For your safety we have commented these instructions out, so you will have to uncomment the instructions for the files to be copied.
+
+### Docker Compose
 This is just a working example of how a docker image could be built for this project and composed with other images such as a `redis` one for cache (check [docker-compose](docker-compose.yml)). Any contributions to make it better are very welcome.
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,25 +38,25 @@ The Dockerfiles can also copy `conf` files found in the `/docker/conf` project d
 
 In case you're not familiar with [Docker](https://docs.docker.com/), here are some basic commands for getting going.
 
-Build Container:
+#### Build Container:
 ```sh
 # Ensure your PWD is either project root or /docker
 docker build -t mosquitto-go-auth .
 ```
 
-Run Container:
+#### Run Container:
 ```sh
 # This command will run the container and map the corresponding ports locally.
 # You can access Mosquitto running inside the container on localhost:1883 and localhost:1884 (WebSockets)
 docker run -it -p 1884:1884 -p 1883:1883 mosquitto-go-auth 
 ```
 
-Stop Container:
+#### Stop Container:
 ```sh
 docker stop $(docker ps -q --filter ancestor=mosquitto-go-auth)
 ```
 
-Remove Container locally:
+#### Remove Container locally:
 ```sh
 docker rmi $(docker images -q --filter reference='mosquitto-go-auth:*')
 ```


### PR DESCRIPTION
This pull request adds support for building a Docker container using the local source code.

I had to move this out to the root directory because `docker build` command will not let you traverse outside of it's pwd (e.g. ../).

In addition to the Dockerfile, I also added a lot of detail to the `README` in the `/docker` directory.

I hope you will consider merging this PR -- if I need to update or clean up anything, please let me know.