### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ and it is loaded into Mosquitto auth with the ```auth_plugin``` option.
 Set path to plugin and include conf.d dir for further configuration:
 
 ```
-auth_plugin /path/to/auth-plug.so
+auth_plugin /path/to/go-auth.so
 include_dir /etc/mosquitto/conf.d
 ```
 


### PR DESCRIPTION
Documentation (tutorial) specifies to use "auth-plugin.so"  when specifying the auth_plugin in .conf file for the mosquitto, but compiled binary file produced by following the tutorial is named "go-auth.so"

Is it possible this was a mistake which originated from the jpmens/mosquitto-auth-plug, as that project uses the auth-plugin.so name for the binary file?



