### PR TITLE
added http timeout config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ The following `auth_opt_` options are supported:
 | http_verify_peer   | false             |      N      | Whether to verify peer for tls    |
 | http_response_mode | status            |      N      | Response type (status, json, text)|
 | http_params_mode   | json              |      N      | Data type (json, form)            |
+| http_timeout       | 5                 |      N      | Timeout in seconds                |
 
 
 #### Response mode

--- a/backends/http.go
+++ b/backends/http.go
@@ -25,6 +25,7 @@ type HTTP struct {
 	VerifyPeer   bool
 	ParamsMode   string
 	ResponseMode string
+	Timeout      int
 	Client       *h.Client
 }
 
@@ -105,11 +106,20 @@ func NewHTTP(authOpts map[string]string, logLevel log.Level) (HTTP, error) {
 		http.VerifyPeer = true
 	}
 
+	http.Timeout = 5
+	if timeoutString, ok := authOpts["http_timeout"]; ok {
+		if timeout, err := strconv.Atoi(timeoutString); err != nil {
+			http.Timeout = timeout
+		} else {
+			log.Errorf("unable to parse timeout: %s", err)
+		}
+	}
+
 	if !httpOk {
 		return http, errors.Errorf("HTTP backend error: missing remote options: %s", missingOpts)
 	}
 
-	http.Client = &h.Client{Timeout: 5 * time.Second}
+	http.Client = &h.Client{Timeout: time.Duration(http.Timeout) * time.Second}
 
 	if !http.VerifyPeer {
 		tr := &h.Transport{

--- a/backends/http.go
+++ b/backends/http.go
@@ -108,7 +108,7 @@ func NewHTTP(authOpts map[string]string, logLevel log.Level) (HTTP, error) {
 
 	http.Timeout = 5
 	if timeoutString, ok := authOpts["http_timeout"]; ok {
-		if timeout, err := strconv.Atoi(timeoutString); err != nil {
+		if timeout, err := strconv.Atoi(timeoutString); err == nil {
 			http.Timeout = timeout
 		} else {
 			log.Errorf("unable to parse timeout: %s", err)

--- a/backends/http_test.go
+++ b/backends/http_test.go
@@ -95,6 +95,7 @@ func TestHTTPAllJsonServer(t *testing.T) {
 	authOpts["http_getuser_uri"] = "/user"
 	authOpts["http_superuser_uri"] = "/superuser"
 	authOpts["http_aclcheck_uri"] = "/acl"
+	authOpts["http_timeout"] = "5"
 
 	Convey("Given correct options an http backend instance should be returned", t, func() {
 		hb, err := NewHTTP(authOpts, log.DebugLevel)


### PR DESCRIPTION
This PR makes the http client timeout configurable. This is useful in a microservice environment when the authentication webservice takes a few seconds to startup.