### PR TITLE
Add local go-cache and handle redis cluster MOVED errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ dev-requirements:
 
 test:
 	go test ./backends -v -bench=none -count=1
+	go test ./cache -v -bench=none -count=1
 
 benchmark:
 	go test ./backends -v -bench=. -run=^a

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ dev-requirements:
 	go get -u github.com/smartystreets/goconvey
 
 test:
-	go test ./backends -v -bench=none -count=1
-	go test ./cache -v -bench=none -count=1
+	go test ./backends ./cache -v -bench=none -count=1
 
 benchmark:
 	go test ./backends -v -bench=. -run=^a

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ auth_opt_backends files, postgres, jwt
 
 #### Cache
 
-There are 2 types of cache supported: an in memory one using [go-cache](https://github.com/patrickmn/go-cache), or a Redis backed one.
+There are 2 types of caches supported: an in memory one using [go-cache](https://github.com/patrickmn/go-cache), or a Redis backed one.
+
 Set `cache` option to true to use a cache (defaults to false when missing) and `cache_type` to set the type of the cache. By default the plugin will use `go-cache` unless explicitly told to use Redis.
 Set `cache_reset` to flush the cache on mosquitto startup (**hydrating `go-cache` on startup is not yet supported**).
 

--- a/README.md
+++ b/README.md
@@ -242,34 +242,40 @@ auth_opt_backends files, postgres, jwt
 
 #### Cache
 
-Set cache option to true to use redis cache (defaults to false when missing). Also, set `cache_reset` to flush the redis DB on mosquitto startup:
+There are 2 types of cache supported: an in memory one using [go-cache](https://github.com/patrickmn/go-cache), or a Redis backed one.
+Set `cache` option to true to use a cache (defaults to false when missing) and `cache_type` to set the type of the cache. By default the plugin will use `go-cache` unless explicitly told to use Redis.
+Set `cache_reset` to flush the cache on mosquitto startup (**hydrating `go-cache` on startup is not yet supported**).
+
+Finally, set expiration times in seconds for authentication (`auth`) and authorization (`acl`) caches:
 
 ```
 auth_opt_cache true
+auth_opt_cache_type redis
 auth_opt_cache_reset true
+
+auth_opt_auth_cache_seconds 30
+auth_opt_acl_cache_seconds 30
 ```
 
 If `cache_reset` is set to false or omitted, cache won't be flushed upon service start.
 
-Redis will use the following defaults if no values are given. Also, these are the available options for cache:
+When using Redis, the following defaults will be used if no values are given. Also, these are the available options for cache:
 
 ```
 auth_opt_cache_host localhost
 auth_opt_cache_port 6379
 auth_opt_cache_password pwd
 auth_opt_cache_db 3
-auth_opt_auth_cache_seconds 30
-auth_opt_acl_cache_seconds 30
 ```
 
-If you want to use a Redis cluster as your cache, you need to set `auth_opt_cache_mode` to `cluster` and provide the different addresses as a list of comma separated `host:port` strings with the `auth_opt_cache_addresses` options:
+If you want to use a Redis cluster as your cache, you may omit previous Redis options and instead need to set `auth_opt_cache_mode` to `cluster` and provide the different addresses as a list of comma separated `host:port` strings with the `auth_opt_cache_addresses` options:
 
 ```
 auth_opt_cache_mode cluster
 auth_opt_cache_addresses host1:port1,host2:port2,host3:port3
 ```
 
-Notice that if `cache_mode` is not provided or isn't equal to `cluster`, cache will default to use a single instance with the common options. If instead the mode is correctly set to `cluster` but no addresses are given, the plugin will default to not use a cache.
+Notice that if `cache_mode` is not provided or isn't equal to `cluster`, cache will default to use a single instance with the common options. If instead the mode is set to `cluster` but no addresses are given, the plugin will default to not use a cache.
 
 #### Logging
 

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -118,7 +118,7 @@ func NewRedis(authOpts map[string]string, logLevel log.Level) (Redis, error) {
 			Password: redis.Password,
 			DB:       int(redis.DB),
 		})
-		redis.conn = SingleRedisClient{redisClient}
+		redis.conn = &SingleRedisClient{redisClient}
 	}
 
 	for {
@@ -135,7 +135,7 @@ func NewRedis(authOpts map[string]string, logLevel log.Level) (Redis, error) {
 }
 
 // Checks if an error was caused by a moved record in a cluster.
-func IsMovedError(err error) bool {
+func isMovedError(err error) bool {
 	s := err.Error()
 	if strings.HasPrefix(s, "MOVED ") || strings.HasPrefix(s, "ASK ") {
 		return true
@@ -152,7 +152,7 @@ func (o Redis) GetUser(username, password, _ string) bool {
 	}
 
 	//If using Redis Cluster, reload state and attempt once more.
-	if IsMovedError(err) {
+	if isMovedError(err) {
 		err = o.conn.ReloadState(o.ctx)
 		if err != nil {
 			log.Debugf("redis reload state error: %s", err)
@@ -194,7 +194,7 @@ func (o Redis) GetSuperuser(username string) bool {
 	}
 
 	//If using Redis Cluster, reload state and attempt once more.
-	if IsMovedError(err) {
+	if isMovedError(err) {
 		err = o.conn.ReloadState(o.ctx)
 		if err != nil {
 			log.Debugf("redis reload state error: %s", err)
@@ -231,7 +231,7 @@ func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
 	}
 
 	//If using Redis Cluster, reload state and attempt once more.
-	if IsMovedError(err) {
+	if isMovedError(err) {
 		err = o.conn.ReloadState(o.ctx)
 		if err != nil {
 			log.Debugf("redis reload state error: %s", err)

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -2,6 +2,7 @@ package backends
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -21,6 +22,17 @@ type RedisClient interface {
 	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *goredis.StatusCmd
 	SAdd(ctx context.Context, key string, members ...interface{}) *goredis.IntCmd
 	Expire(ctx context.Context, key string, expiration time.Duration) *goredis.BoolCmd
+	ReloadState(ctx context.Context) error
+}
+
+type SingleRedisClient struct {
+	*goredis.Client
+}
+
+var SingleClientError = errors.New("unsupported reload state operation for Redis single client")
+
+func (c SingleRedisClient) ReloadState(ctx context.Context) error {
+	return SingleClientError
 }
 
 type Redis struct {
@@ -106,7 +118,7 @@ func NewRedis(authOpts map[string]string, logLevel log.Level) (Redis, error) {
 			Password: redis.Password,
 			DB:       int(redis.DB),
 		})
-		redis.conn = redisClient
+		redis.conn = SingleRedisClient{redisClient}
 	}
 
 	for {
@@ -122,48 +134,122 @@ func NewRedis(authOpts map[string]string, logLevel log.Level) (Redis, error) {
 
 }
 
-//GetUser checks that the username exists and the given password hashes to the same password.
-func (o Redis) GetUser(username, password, clientid string) bool {
-
-	pwHash, err := o.conn.Get(o.ctx, username).Result()
-
-	if err != nil {
-		log.Debugf("Redis get user error: %s", err)
-		return false
-	}
-
-	if common.HashCompare(password, pwHash, o.SaltEncoding) {
+// Checks if an error was caused by a moved record in a cluster.
+func IsMovedError(err error) bool {
+	s := err.Error()
+	if strings.HasPrefix(s, "MOVED ") || strings.HasPrefix(s, "ASK ") {
 		return true
 	}
 
 	return false
+}
 
+//GetUser checks that the username exists and the given password hashes to the same password.
+func (o Redis) GetUser(username, password, _ string) bool {
+	ok, err := o.getUser(username, password)
+	if err == nil {
+		return ok
+	}
+
+	//If using Redis Cluster, reload state and attempt once more.
+	if IsMovedError(err) {
+		err = o.conn.ReloadState(o.ctx)
+		if err != nil {
+			log.Debugf("redis reload state error: %s", err)
+			return false
+		}
+
+		//Retry once.
+		ok, err = o.getUser(username, password)
+	}
+
+	if err != nil {
+		log.Debugf("redis get user error: %s", err)
+	}
+	return ok
+}
+
+func (o Redis) getUser(username, password string) (bool, error) {
+	pwHash, err := o.conn.Get(o.ctx, username).Result()
+	if err != nil {
+		return false, err
+	}
+
+	if common.HashCompare(password, pwHash, o.SaltEncoding) {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 //GetSuperuser checks that the key username:su exists and has value "true".
 func (o Redis) GetSuperuser(username string) bool {
-
 	if o.disableSuperuser {
 		return false
 	}
 
-	isSuper, err := o.conn.Get(o.ctx, fmt.Sprintf("%s:su", username)).Result()
+	ok, err := o.getSuperuser(username)
+	if err == nil {
+		return ok
+	}
+
+	//If using Redis Cluster, reload state and attempt once more.
+	if IsMovedError(err) {
+		err = o.conn.ReloadState(o.ctx)
+		if err != nil {
+			log.Debugf("redis reload state error: %s", err)
+			return false
+		}
+
+		//Retry once.
+		ok, err = o.getSuperuser(username)
+	}
 
 	if err != nil {
-		log.Debugf("Redis get superuser error: %s", err)
-		return false
+		log.Debugf("redis get superuser error: %s", err)
+	}
+	return ok
+}
+
+func (o Redis) getSuperuser(username string) (bool, error) {
+	isSuper, err := o.conn.Get(o.ctx, fmt.Sprintf("%s:su", username)).Result()
+	if err != nil {
+		return false, err
 	}
 
 	if isSuper == "true" {
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
+}
 
+func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
+	ok, err := o.checkAcl(username, topic, clientid, acc)
+	if err == nil {
+		return ok
+	}
+
+	//If using Redis Cluster, reload state and attempt once more.
+	if IsMovedError(err) {
+		err = o.conn.ReloadState(o.ctx)
+		if err != nil {
+			log.Debugf("redis reload state error: %s", err)
+			return false
+		}
+
+		//Retry once.
+		ok, err = o.checkAcl(username, topic, clientid, acc)
+	}
+
+	if err != nil {
+		log.Debugf("redis check acl error: %s", err)
+	}
+	return ok
 }
 
 //CheckAcl gets all acls for the username and tries to match against topic, acc, and username/clientid if needed.
-func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
+func (o Redis) checkAcl(username, topic, clientid string, acc int32) (bool, error) {
 
 	var acls []string       //User specific acls.
 	var commonAcls []string //Common acls.
@@ -175,40 +261,34 @@ func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
 		var err error
 		acls, err = o.conn.SMembers(o.ctx, fmt.Sprintf("%s:sacls", username)).Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 
 		//Get common subscribe acls.
 		commonAcls, err = o.conn.SMembers(o.ctx, "common:sacls").Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 
 	case MOSQ_ACL_READ:
 		//Get all user read and readwrite acls.
 		urAcls, err := o.conn.SMembers(o.ctx, fmt.Sprintf("%s:racls", username)).Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 		urwAcls, err := o.conn.SMembers(o.ctx, fmt.Sprintf("%s:rwacls", username)).Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 
 		//Get common read and readwrite acls
 		rAcls, err := o.conn.SMembers(o.ctx, "common:racls").Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 		rwAcls, err := o.conn.SMembers(o.ctx, "common:rwacls").Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 
 		acls = make([]string, len(urAcls)+len(urwAcls))
@@ -222,25 +302,21 @@ func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
 		//Get all user write and readwrite acls.
 		uwAcls, err := o.conn.SMembers(o.ctx, fmt.Sprintf("%s:wacls", username)).Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 		urwAcls, err := o.conn.SMembers(o.ctx, fmt.Sprintf("%s:rwacls", username)).Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 
 		//Get common write and readwrite acls
 		wAcls, err := o.conn.SMembers(o.ctx, "common:wacls").Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 		rwAcls, err := o.conn.SMembers(o.ctx, "common:rwacls").Result()
 		if err != nil {
-			log.Debugf("Redis check acl error: %s", err)
-			return false
+			return false, err
 		}
 
 		acls = make([]string, len(uwAcls)+len(urwAcls))
@@ -255,7 +331,7 @@ func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
 	//Now loop through acls looking for a match.
 	for _, acl := range acls {
 		if common.TopicsMatch(acl, topic) {
-			return true
+			return true, nil
 		}
 	}
 
@@ -263,12 +339,11 @@ func (o Redis) CheckAcl(username, topic, clientid string, acc int32) bool {
 		aclTopic := strings.Replace(acl, "%c", clientid, -1)
 		aclTopic = strings.Replace(aclTopic, "%u", username, -1)
 		if common.TopicsMatch(aclTopic, topic) {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
-
+	return false, nil
 }
 
 //GetName returns the backend's name

--- a/backends/redis_test.go
+++ b/backends/redis_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRedis(t *testing.T) {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,271 @@
+package cache
+
+import (
+	"context"
+	b64 "encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	goredis "github.com/go-redis/redis/v8"
+	bes "github.com/iegomez/mosquitto-go-auth/backends"
+	goCache "github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
+)
+
+// redisCache stores necessary values for Redis cache
+type redisStore struct {
+	authExpiration int64
+	aclExpiration  int64
+	client         bes.RedisClient
+}
+
+type goStore struct {
+	authExpiration int64
+	aclExpiration  int64
+	client         *goCache.Cache
+}
+
+const (
+	defaultExpiration = 30
+)
+
+type Store interface {
+	SetAuthRecord(ctx context.Context, username, password, granted string) error
+	CheckAuthRecord(ctx context.Context, username, password string) (bool, bool)
+	SetACLRecord(ctx context.Context, username, topic, clientid string, acc int, granted string) error
+	CheckACLRecord(ctx context.Context, username, topic, clientid string, acc int) (bool, bool)
+	Connect(ctx context.Context, reset bool) bool
+	Close()
+}
+
+// NewGoStore initializes a cache using go-cache as the store.
+func NewGoStore(authExpiration, aclExpiration int64) *goStore {
+	// TODO: support hydrating the cache to retain previous values.
+
+	return &goStore{
+		authExpiration: authExpiration,
+		aclExpiration:  aclExpiration,
+		client:         goCache.New(time.Second*defaultExpiration, time.Second*(defaultExpiration*2)),
+	}
+}
+
+// NewSingleRedisStore initializes a cache using a single Redis instance as the store.
+func NewSingleRedisStore(host, port, password string, db int, authExpiration, aclExpiration int64) *redisStore {
+	addr := fmt.Sprintf("%s:%s", host, port)
+	redisClient := goredis.NewClient(&goredis.Options{
+		Addr:     addr,
+		Password: password, // no password set
+		DB:       db,       // use default db
+	})
+	//If cache is on, try to start redis.
+	return &redisStore{
+		authExpiration: authExpiration,
+		aclExpiration:  aclExpiration,
+		client:         bes.SingleRedisClient{redisClient},
+	}
+}
+
+// NewSingleRedisStore initializes a cache using a Redis Cluster as the store.
+func NewRedisClusterStore(password string, addresses []string, authExpiration, aclExpiration int64) *redisStore {
+	clusterClient := goredis.NewClusterClient(
+		&goredis.ClusterOptions{
+			Addrs:    addresses,
+			Password: password,
+		})
+
+	return &redisStore{
+		authExpiration: authExpiration,
+		aclExpiration:  aclExpiration,
+		client:         clusterClient,
+	}
+}
+
+func toAuthRecord(username, password string) string {
+	return b64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("auth-%s-%s", username, password)))
+}
+
+func toACLRecord(username, topic, clientid string, acc int) string {
+	return b64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("acl-%s-%s-%s-%d", username, topic, clientid, acc)))
+}
+
+// Checks if an error was caused by a moved record in a Redis Cluster.
+func isMovedError(err error) bool {
+	s := err.Error()
+	if strings.HasPrefix(s, "MOVED ") || strings.HasPrefix(s, "ASK ") {
+		return true
+	}
+
+	return false
+}
+
+// Connect flushes the cache if reset is set.
+func (o *goStore) Connect(ctx context.Context, reset bool) bool {
+	log.Infoln("started go-cache")
+	if reset {
+		o.client.Flush()
+		log.Infoln("flushed go-cache")
+	}
+	return true
+}
+
+// Connect pings Redis and flushes the cache if reset is set.
+func (o *redisStore) Connect(ctx context.Context, reset bool) bool {
+	_, err := o.client.Ping(ctx).Result()
+	if err != nil {
+		log.Errorf("couldn't start redis. error: %s", err)
+		return false
+	} else {
+		log.Infoln("started redis cachet")
+		//Check if cache must be reset
+		if reset {
+			o.client.FlushDB(ctx)
+			log.Infoln("flushed redis cache")
+		}
+	}
+	return true
+}
+
+func (o *goStore) Close() {
+	//TODO: support serializing cache for re hydration.
+}
+
+func (o *redisStore) Close() {
+	o.client.Close()
+}
+
+// CheckAuthRecord checks if the username/password pair is present in the cache. Return if it's present and, if so, if it was granted privileges
+func (o *goStore) CheckAuthRecord(ctx context.Context, username, password string) (bool, bool) {
+	record := toAuthRecord(username, password)
+	return o.checkRecord(ctx, record, o.authExpiration)
+}
+
+//CheckAclCache checks if the username/topic/clientid/acc mix is present in the cache. Return if it's present and, if so, if it was granted privileges.
+func (o *goStore) CheckACLRecord(ctx context.Context, username, topic, clientid string, acc int) (bool, bool) {
+	record := toACLRecord(username, topic, clientid, acc)
+	return o.checkRecord(ctx, record, o.aclExpiration)
+}
+
+func (o *goStore) checkRecord(ctx context.Context, record string, expirationTime int64) (bool, bool) {
+	granted := false
+	v, present := o.client.Get(record)
+
+	if present {
+		value, ok := v.(string)
+		if ok && value == "true" {
+			granted = true
+		}
+
+		o.client.Set(record, value, time.Duration(expirationTime))
+	}
+	return present, granted
+}
+
+// CheckAuthRecord checks if the username/password pair is present in the cache. Return if it's present and, if so, if it was granted privileges
+func (o *redisStore) CheckAuthRecord(ctx context.Context, username, password string) (bool, bool) {
+	record := toAuthRecord(username, password)
+	return o.checkRecord(ctx, record, o.authExpiration)
+}
+
+//CheckAclCache checks if the username/topic/clientid/acc mix is present in the cache. Return if it's present and, if so, if it was granted privileges.
+func (o *redisStore) CheckACLRecord(ctx context.Context, username, topic, clientid string, acc int) (bool, bool) {
+	record := toACLRecord(username, topic, clientid, acc)
+	return o.checkRecord(ctx, record, o.aclExpiration)
+}
+
+func (o *redisStore) checkRecord(ctx context.Context, record string, expirationTime int64) (bool, bool) {
+
+	present, granted, err := o.getAndRefresh(ctx, record, expirationTime)
+	if err == nil {
+		return present, granted
+	}
+
+	if isMovedError(err) {
+		err = o.client.ReloadState(ctx)
+		// This should not happen, ever!
+		if err == bes.SingleClientError {
+			return false, false
+		}
+
+		//Retry once.
+		present, granted, err = o.getAndRefresh(ctx, record, expirationTime)
+	}
+
+	if err != nil {
+		log.Debugf("set cache error: %s", err)
+	}
+
+	return present, granted
+}
+
+func (o *redisStore) getAndRefresh(ctx context.Context, record string, expirationTime int64) (bool, bool, error) {
+	val, err := o.client.Get(ctx, record).Result()
+	if err != nil {
+		return false, false, err
+	}
+
+	//refresh expiration
+	_, err = o.client.Expire(ctx, record, time.Duration(expirationTime)*time.Second).Result()
+	if err != nil {
+		return false, false, err
+	}
+
+	if val == "true" {
+		return true, true, nil
+	}
+
+	return true, false, nil
+}
+
+// SetAuthRecord sets a pair, granted option and expiration time.
+func (o *goStore) SetAuthRecord(ctx context.Context, username, password string, granted string) error {
+	record := toAuthRecord(username, password)
+	o.client.Set(record, granted, time.Duration(o.authExpiration))
+
+	return nil
+}
+
+//SetAclCache sets a mix, granted option and expiration time.
+func (o *goStore) SetACLRecord(ctx context.Context, username, topic, clientid string, acc int, granted string) error {
+	record := toACLRecord(username, topic, clientid, acc)
+	o.client.Set(record, granted, time.Duration(o.authExpiration))
+
+	return nil
+}
+
+// SetAuthRecord sets a pair, granted option and expiration time.
+func (o *redisStore) SetAuthRecord(ctx context.Context, username, password string, granted string) error {
+	record := toAuthRecord(username, password)
+	return o.setRecord(ctx, record, granted, o.authExpiration)
+}
+
+//SetAclCache sets a mix, granted option and expiration time.
+func (o *redisStore) SetACLRecord(ctx context.Context, username, topic, clientid string, acc int, granted string) error {
+	record := toACLRecord(username, topic, clientid, acc)
+	return o.setRecord(ctx, record, granted, o.authExpiration)
+}
+
+func (o *redisStore) setRecord(ctx context.Context, record, granted string, expirationTime int64) error {
+	err := o.set(ctx, record, granted, expirationTime)
+
+	if err == nil {
+		return nil
+	}
+
+	// If record was moved, reload and retry.
+	if isMovedError(err) {
+		err = o.client.ReloadState(ctx)
+		if err != nil {
+			return err
+		}
+
+		//Retry once.
+		err = o.set(ctx, record, granted, expirationTime)
+	}
+
+	return err
+}
+
+func (o *redisStore) set(ctx context.Context, record string, granted string, expirationTime int64) error {
+	return o.client.Set(ctx, record, granted, time.Duration(expirationTime)*time.Second).Err()
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -156,7 +156,7 @@ func (s *goStore) checkRecord(ctx context.Context, record string, expirationTime
 			granted = true
 		}
 
-		s.client.Set(record, value, time.Duration(expirationTime))
+		s.client.Set(record, value, time.Second*time.Duration(expirationTime))
 	}
 	return present, granted
 }
@@ -220,7 +220,7 @@ func (s *redisStore) getAndRefresh(ctx context.Context, record string, expiratio
 // SetAuthRecord sets a pair, granted option and expiration time.
 func (s *goStore) SetAuthRecord(ctx context.Context, username, password string, granted string) error {
 	record := toAuthRecord(username, password)
-	s.client.Set(record, granted, time.Duration(s.authExpiration))
+	s.client.Set(record, granted, time.Second*time.Duration(s.authExpiration))
 
 	return nil
 }
@@ -228,7 +228,7 @@ func (s *goStore) SetAuthRecord(ctx context.Context, username, password string, 
 //SetAclCache sets a mix, granted option and expiration time.
 func (s *goStore) SetACLRecord(ctx context.Context, username, topic, clientid string, acc int, granted string) error {
 	record := toACLRecord(username, topic, clientid, acc)
-	s.client.Set(record, granted, time.Duration(s.authExpiration))
+	s.client.Set(record, granted, time.Second*time.Duration(s.authExpiration))
 
 	return nil
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestGoStore(t *testing.T) {
-	authSeconds := int64(1)
-	aclSeconds := int64(1)
-	store := NewGoStore(authSeconds, aclSeconds)
+	authExpiration := 100 * time.Millisecond
+	aclExpiration := 100 * time.Millisecond
+	store := NewGoStore(authExpiration, aclExpiration)
 
 	ctx := context.Background()
 
-	assert.Equal(t, authSeconds, store.authExpiration)
-	assert.Equal(t, aclSeconds, store.aclExpiration)
+	assert.Equal(t, authExpiration, store.authExpiration)
+	assert.Equal(t, aclExpiration, store.aclExpiration)
 
 	assert.True(t, store.Connect(ctx, false))
 
@@ -35,7 +35,7 @@ func TestGoStore(t *testing.T) {
 	assert.True(t, granted)
 
 	// Wait for it to expire.
-	time.Sleep(1 * time.Second)
+	time.Sleep(150 * time.Millisecond)
 
 	present, granted = store.CheckAuthRecord(ctx, username, password)
 
@@ -51,7 +51,7 @@ func TestGoStore(t *testing.T) {
 	assert.True(t, granted)
 
 	// Wait for it to expire.
-	time.Sleep(1 * time.Second)
+	time.Sleep(150 * time.Millisecond)
 
 	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
 
@@ -68,7 +68,7 @@ func TestGoStore(t *testing.T) {
 	assert.False(t, granted)
 
 	// Wait for it to expire.
-	time.Sleep(1 * time.Second)
+	time.Sleep(150 * time.Millisecond)
 
 	present, granted = store.CheckAuthRecord(ctx, username, password)
 
@@ -84,11 +84,135 @@ func TestGoStore(t *testing.T) {
 	assert.False(t, granted)
 
 	// Wait for it to expire.
-	time.Sleep(1 * time.Second)
+	time.Sleep(150 * time.Millisecond)
 
 	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
 
 	assert.False(t, present)
 	assert.False(t, granted)
 
+}
+
+func TestRedisSingleStore(t *testing.T) {
+	authExpiration := 1000 * time.Millisecond
+	aclExpiration := 1000 * time.Millisecond
+	store := NewSingleRedisStore("localhost", "6379", "", 3, authExpiration, aclExpiration)
+
+	ctx := context.Background()
+
+	assert.Equal(t, authExpiration, store.authExpiration)
+	assert.Equal(t, aclExpiration, store.aclExpiration)
+
+	assert.True(t, store.Connect(ctx, false))
+
+	username := "test-user"
+	password := "test-password"
+	topic := "test/topic"
+	acc := 1
+
+	// Test granted access.
+	err := store.SetAuthRecord(ctx, username, password, "true")
+	assert.Nil(t, err)
+
+	present, granted := store.CheckAuthRecord(ctx, username, password)
+
+	assert.True(t, present)
+	assert.True(t, granted)
+
+	// Wait for it to expire. For Redis we do this just once since the package used (or Redis itself, not sure) doesn't
+	// support less than 1s expiration times: "specified duration is 100ms, but minimal supported value is 1s"
+	time.Sleep(1050 * time.Millisecond)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.False(t, present)
+	assert.False(t, granted)
+
+	err = store.SetACLRecord(ctx, username, password, topic, acc, "true")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.True(t, present)
+	assert.True(t, granted)
+
+	// Test not granted access.
+	err = store.SetAuthRecord(ctx, username, password, "false")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.True(t, present)
+	assert.False(t, granted)
+
+	err = store.SetACLRecord(ctx, username, password, topic, acc, "false")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.True(t, present)
+	assert.False(t, granted)
+}
+
+func TestRedisClusterStore(t *testing.T) {
+	authExpiration := 1000 * time.Millisecond
+	aclExpiration := 1000 * time.Millisecond
+
+	addresses := []string{"localhost:7000", "localhost:7001", "localhost:7002"}
+	store := NewRedisClusterStore("", addresses, authExpiration, aclExpiration)
+
+	ctx := context.Background()
+
+	assert.Equal(t, authExpiration, store.authExpiration)
+	assert.Equal(t, aclExpiration, store.aclExpiration)
+
+	assert.True(t, store.Connect(ctx, false))
+
+	username := "test-user"
+	password := "test-password"
+	topic := "test/topic"
+	acc := 1
+
+	// Test granted access.
+	err := store.SetAuthRecord(ctx, username, password, "true")
+	assert.Nil(t, err)
+
+	present, granted := store.CheckAuthRecord(ctx, username, password)
+
+	assert.True(t, present)
+	assert.True(t, granted)
+
+	// Wait for it to expire. For Redis we do this just once since the package used (or Redis itself, not sure) doesn't
+	// support less than 1s expiration times: "specified duration is 100ms, but minimal supported value is 1s"
+	time.Sleep(1050 * time.Millisecond)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.False(t, present)
+	assert.False(t, granted)
+
+	err = store.SetACLRecord(ctx, username, password, topic, acc, "true")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.True(t, present)
+	assert.True(t, granted)
+
+	// Test not granted access.
+	err = store.SetAuthRecord(ctx, username, password, "false")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.True(t, present)
+	assert.False(t, granted)
+
+	err = store.SetACLRecord(ctx, username, password, topic, acc, "false")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.True(t, present)
+	assert.False(t, granted)
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,94 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoStore(t *testing.T) {
+	authSeconds := int64(1)
+	aclSeconds := int64(1)
+	store := NewGoStore(authSeconds, aclSeconds)
+
+	ctx := context.Background()
+
+	assert.Equal(t, authSeconds, store.authExpiration)
+	assert.Equal(t, aclSeconds, store.aclExpiration)
+
+	assert.True(t, store.Connect(ctx, false))
+
+	username := "test-user"
+	password := "test-password"
+	topic := "test/topic"
+	acc := 1
+
+	// Test granted access.
+	err := store.SetAuthRecord(ctx, username, password, "true")
+	assert.Nil(t, err)
+
+	present, granted := store.CheckAuthRecord(ctx, username, password)
+
+	assert.True(t, present)
+	assert.True(t, granted)
+
+	// Wait for it to expire.
+	time.Sleep(1 * time.Second)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.False(t, present)
+	assert.False(t, granted)
+
+	err = store.SetACLRecord(ctx, username, password, topic, acc, "true")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.True(t, present)
+	assert.True(t, granted)
+
+	// Wait for it to expire.
+	time.Sleep(1 * time.Second)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.False(t, present)
+	assert.False(t, granted)
+
+	// Test not granted access.
+	err = store.SetAuthRecord(ctx, username, password, "false")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.True(t, present)
+	assert.False(t, granted)
+
+	// Wait for it to expire.
+	time.Sleep(1 * time.Second)
+
+	present, granted = store.CheckAuthRecord(ctx, username, password)
+
+	assert.False(t, present)
+	assert.False(t, granted)
+
+	err = store.SetACLRecord(ctx, username, password, topic, acc, "false")
+	assert.Nil(t, err)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.True(t, present)
+	assert.False(t, granted)
+
+	// Wait for it to expire.
+	time.Sleep(1 * time.Second)
+
+	present, granted = store.CheckACLRecord(ctx, username, password, topic, acc)
+
+	assert.False(t, present)
+	assert.False(t, granted)
+
+}

--- a/go-auth.go
+++ b/go-auth.go
@@ -8,6 +8,7 @@ import (
 	"plugin"
 	"strconv"
 	"strings"
+	"time"
 
 	bes "github.com/iegomez/mosquitto-go-auth/backends"
 	"github.com/iegomez/mosquitto-go-auth/cache"
@@ -424,7 +425,7 @@ func setCache(authOpts map[string]string) {
 				addresses[i] = strings.TrimSpace(addresses[i])
 			}
 
-			authPlugin.cache = cache.NewRedisClusterStore(password, addresses, authCacheSeconds, aclCacheSeconds)
+			authPlugin.cache = cache.NewRedisClusterStore(password, addresses, time.Duration(authCacheSeconds)*time.Second, time.Duration(aclCacheSeconds)*time.Second)
 
 		} else {
 			if cacheHost, ok := authOpts["cache_host"]; ok {
@@ -444,11 +445,11 @@ func setCache(authOpts map[string]string) {
 				}
 			}
 
-			authPlugin.cache = cache.NewSingleRedisStore(host, port, password, db, authCacheSeconds, aclCacheSeconds)
+			authPlugin.cache = cache.NewSingleRedisStore(host, port, password, db, time.Duration(authCacheSeconds)*time.Second, time.Duration(aclCacheSeconds)*time.Second)
 		}
 
 	default:
-		authPlugin.cache = cache.NewGoStore(authCacheSeconds, aclCacheSeconds)
+		authPlugin.cache = cache.NewGoStore(time.Duration(authCacheSeconds)*time.Second, time.Duration(aclCacheSeconds)*time.Second)
 	}
 
 	if !authPlugin.cache.Connect(authPlugin.ctx, reset) {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/klauspost/compress v1.10.6 // indirect
 	github.com/lib/pq v1.5.2
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
@@ -32,7 +33,7 @@ require (
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
 	google.golang.org/api v0.6.0 // indirect
-	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/appengine v1.6.5
 	google.golang.org/genproto v0.0.0-20200521103424-e9a78aa275b7 // indirect
 	google.golang.org/grpc v1.29.1
 )

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,9 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/patrickmn/go-cache v1.0.0 h1:3gD5McaYs9CxjyK5AXGcq8gdeCARtd/9gJDUvVeaZ0Y=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -358,6 +361,7 @@ google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
This PR adds a new local cache using the package [go-cache](https://github.com/patrickmn/go-cache) and handles Redis `MOVED` errors by reloading cluster state and retrying once. It involves a whole refactor including moving cache to its own package for cleanness and testability.

As mentioned in https://github.com/iegomez/mosquitto-go-auth/issues/60, this may be a poor strategy for cache purposes, but is nonetheless relevant for the Redis plugin itself.