### PR TITLE
Add Docker image to run tests

### DIFF
--- a/Dockerfile.runtest
+++ b/Dockerfile.runtest
@@ -1,0 +1,46 @@
+
+#Use debian:stable-slim as a builder and then copy everything.
+FROM debian:stable-slim as builder
+
+#Set mosquitto and plugin versions.
+#Change them for your needs.
+ENV MOSQUITTO_VERSION=1.6.10
+ENV PLUGIN_VERSION=0.6.1
+ENV GO_VERSION=1.13.8
+
+WORKDIR /app
+
+#Get mosquitto build dependencies.
+RUN apt-get update && apt-get install -y libwebsockets8 libwebsockets-dev libc-ares2 libc-ares-dev openssl uuid uuid-dev wget build-essential git
+RUN mkdir -p mosquitto/auth mosquitto/conf.d
+
+RUN wget http://mosquitto.org/files/source/mosquitto-${MOSQUITTO_VERSION}.tar.gz
+RUN tar xzvf mosquitto-${MOSQUITTO_VERSION}.tar.gz && rm mosquitto-${MOSQUITTO_VERSION}.tar.gz 
+
+#Build mosquitto.
+RUN cd mosquitto-${MOSQUITTO_VERSION} && make WITH_WEBSOCKETS=yes && make install && cd ..
+
+#Get Go.
+RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+RUN export PATH=$PATH:/usr/local/go/bin && go version && rm go${GO_VERSION}.linux-amd64.tar.gz
+
+#Build the plugin from local source
+COPY ./ ./
+
+#Build the plugin.
+RUN export PATH=$PATH:/usr/local/go/bin && export CGO_CFLAGS="-I/usr/local/include -fPIC" && export CGO_LDFLAGS="-shared" &&  make
+
+## Everything above, is the same as Dockerfile
+
+RUN apt-get install --no-install-recommends -y mariadb-server postgresql redis-server sudo
+
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - && \
+    echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main" > /etc/apt/sources.list.d/mongodb-org-4.4.list && \
+    apt-get update && \
+# starting with MongoDB 4.3, the postinst for server includes "systemctl daemon-reload" (and we don't have "systemctl")
+    ln -s /bin/true /usr/bin/systemctl && \
+    apt-get install -y mongodb-org && \
+    rm -f /usr/bin/systemctl
+
+# Pre-compilation of test for speed-up latest re-run
+RUN export PATH=$PATH:/usr/local/go/bin && go test -c ./backends -o /dev/null

--- a/Dockerfile.runtest
+++ b/Dockerfile.runtest
@@ -32,7 +32,7 @@ RUN export PATH=$PATH:/usr/local/go/bin && export CGO_CFLAGS="-I/usr/local/inclu
 
 ## Everything above, is the same as Dockerfile
 
-RUN apt-get install --no-install-recommends -y mariadb-server postgresql redis-server sudo
+RUN apt-get update && apt-get install --no-install-recommends -y mariadb-server postgresql redis-server sudo
 
 RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - && \
     echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main" > /etc/apt/sources.list.d/mongodb-org-4.4.list && \

--- a/README.md
+++ b/README.md
@@ -1332,6 +1332,21 @@ Please read the [documentation](./docker/README.md) in the [docker](/docker) dir
 
 Images are provided on Dockerhub under [iegomez/mosquitto-go-auth](https://hub.docker.com/r/iegomez/mosquitto-go-auth).
 
+### Testing using Docker
+
+Since tests require multiple backends (PostgreSQL, Mysql, Redis...), a Dockerfile.test provide
+and image with all required backend.
+To use it:
+```
+docker build -t mosquitto-go-auth.test -f Dockerfile.runtest .
+docker run --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh
+```
+
+Or using local source (avoid the need to rebuild image):
+```
+docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh
+```
+
 ### License
 
 mosquitto-go-auth is distributed under the MIT license. See also [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,14 @@ Or using local source (avoid the need to rebuild image):
 docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh
 ```
 
+You may even specify the command to run after backends are started, which allow
+to run only some tests or even get a shell inside the containers:
+```
+docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh make test-backends
+
+docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh bash
+```
+
 ### License
 
 mosquitto-go-auth is distributed under the MIT license. See also [LICENSE](LICENSE).

--- a/run-test-in-docker.sh
+++ b/run-test-in-docker.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# This script is make to be run in Docker image build by Dockerfile.test
+
+service postgresql start
+service mysql start
+service redis-server start
+
+sudo -u mongodb mongod --config /etc/mongod.conf &
+
+sudo -u postgres psql << "EOF"
+create user go_auth_test with login password 'go_auth_test';
+create database go_auth_test with owner go_auth_test;
+EOF
+
+psql "user=go_auth_test password=go_auth_test host=127.0.0.1" << "EOF"
+
+create table test_user(
+id bigserial primary key,
+username character varying (100) not null,
+password_hash character varying (200) not null,
+is_admin boolean not null);
+
+create table test_acl(
+id bigserial primary key,
+test_user_id bigint not null references test_user on delete cascade,
+topic character varying (200) not null,
+rw int not null);
+EOF
+
+
+mysql << "EOF"
+create user 'go_auth_test'@'localhost' identified by 'go_auth_test';
+create database go_auth_test;
+grant all privileges on go_auth_test.* to 'go_auth_test'@'localhost';
+EOF
+
+mysql go_auth_test << "EOF"
+create table test_user(
+id mediumint not null auto_increment,
+username varchar(100) not null,
+password_hash varchar(200) not null,
+is_admin boolean not null,
+primary key(id)
+);
+
+create table test_acl(
+id mediumint not null auto_increment,
+test_user_id mediumint not null,
+topic varchar(200) not null,
+rw int not null,
+primary key(id),
+foreign key(test_user_id) references test_user(id)
+ON DELETE CASCADE
+ON UPDATE CASCADE
+);
+EOF
+
+
+mkdir /tmp/cluster-test
+cd /tmp/cluster-test
+mkdir 7000 7001 7002 7003 7004 7005
+cat > 7000/redis.conf << EOF
+port 7000
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes
+EOF
+
+for i in 7001 7002 7003 7004 7005; do
+    sed s/7000/$i/ < 7000/redis.conf > $i/redis.conf
+done
+
+for i in 7000 7001 7002 7003 7004 7005; do
+    (cd $i; redis-server redis.conf > server.log 2>&1 &)
+done
+
+yes yes | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 \
+    127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005 \
+    --cluster-replicas 1
+
+cd /app
+export PATH=$PATH:/usr/local/go/bin
+make test

--- a/run-test-in-docker.sh
+++ b/run-test-in-docker.sh
@@ -81,4 +81,11 @@ yes yes | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 \
 
 cd /app
 export PATH=$PATH:/usr/local/go/bin
-make test
+
+set -x
+
+if [ "$#" -eq 0 ]; then
+    make test
+else
+    exec "$@"
+fi


### PR DESCRIPTION
To run tests (which requires lots of backends), I've used Docker containers.
This PR add steps to rebuild and run test using this Docker image.

It's probably not prefect (sometime Redis cluster fail... not every run) but it allow me to run the tests.