### PR TITLE
Cache jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,10 @@ auth_opt_auth_jitter_seconds 3
 auth_opt_acl_jitter_seconds 3
 ```
 
-The `auth_jitter_seconds` and `acl_jitter_seconds` allow to randomize the expiration used. The value used
-is cache_seconds +/- jitter_seconds. With above values (30 seconds for cache and 3 seconds for jitter), the
-expiration will be between 27 seconds and 33 seconds. The jitter is useful to reduce loopups storm that could
-occur every auth/acl_cache_seconds if lots of clients connected at the same time (for example
-after a server restart, all your clients may reconnect immediatly creating lots of entry expiring at the same time, unless
-a jitter is used). You can set jitter to 0 to disable this feature.
+`auth_jitter_seconds` and `acl_jitter_seconds` options allow to randomize cache expiration time by a given offset
+The value used for expiring a cache record would then be `cache_seconds` +/- `jitter_seconds`. With above values (30 seconds for cache and 3 seconds for jitter), effective expiration would yield any value between 27 and 33 seconds. 
+Setting a `jitter` value is useful to reduce lookups storms that could occur every `auth/acl_cache_seconds` if lots of clients connected at the same time, e.g. after a server restart when all clients may reconnect immediately creating lots of entries expiring at the same time.
+You may omit or set jitter options to 0 to disable this feature.
 
 If `cache_reset` is set to false or omitted, cache won't be flushed upon service start.
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,16 @@ auth_opt_cache_refresh true
 
 auth_opt_auth_cache_seconds 30
 auth_opt_acl_cache_seconds 30
+auth_opt_auth_jitter_seconds 3
+auth_opt_acl_jitter_seconds 3
 ```
+
+The `auth_jitter_seconds` and `acl_jitter_seconds` allow to randomize the expiration used. The value used
+is cache_seconds +/- jitter_seconds. With above values (30 seconds for cache and 3 seconds for jitter), the
+expiration will be between 27 seconds and 33 seconds. The jitter is useful to reduce loopups storm that could
+occur every auth/acl_cache_seconds if lots of clients connected at the same time (for example
+after a server restart, all your clients may reconnect immediatly creating lots of entry expiring at the same time, unless
+a jitter is used). You can set jitter to 0 to disable this feature.
 
 If `cache_reset` is set to false or omitted, cache won't be flushed upon service start.
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -126,9 +126,8 @@ func isMovedError(err error) bool {
 	return false
 }
 
-// return a expiration duration with a jitter added
-// The result is between expiration-jitter and expiration+jitter.
-// Negative value are never returned, 0 is used instead
+// Return an expiration duration with a jitter added, i.e the actual expiration is in the range [expiration - jitter, expiration + jitter].
+// If no expiration was set or jitter > expiration, then any negative value will yield 0 instead.
 func expirationWithJitter(expiration, jitter time.Duration) time.Duration {
 	if jitter == 0 {
 		return expiration

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -185,7 +185,7 @@ func (s *goStore) CheckAuthRecord(ctx context.Context, username, password string
 //CheckAclCache checks if the username/topic/clientid/acc mix is present in the cache. Return if it's present and, if so, if it was granted privileges.
 func (s *goStore) CheckACLRecord(ctx context.Context, username, topic, clientid string, acc int) (bool, bool) {
 	record := toACLRecord(username, topic, clientid, acc, s.h)
-	return s.checkRecord(ctx, record, expirationWithJitter(s.aclExpiration, s.authJitter))
+	return s.checkRecord(ctx, record, expirationWithJitter(s.aclExpiration, s.aclJitter))
 }
 
 func (s *goStore) checkRecord(ctx context.Context, record string, expirationTime time.Duration) (bool, bool) {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -247,7 +247,7 @@ func (s *goStore) SetAuthRecord(ctx context.Context, username, password string, 
 //SetAclCache sets a mix, granted option and expiration time.
 func (s *goStore) SetACLRecord(ctx context.Context, username, topic, clientid string, acc int, granted string) error {
 	record := toACLRecord(username, topic, clientid, acc, s.h)
-	s.client.Set(record, granted, s.authExpiration)
+	s.client.Set(record, granted, s.aclExpiration)
 
 	return nil
 }
@@ -261,7 +261,7 @@ func (s *redisStore) SetAuthRecord(ctx context.Context, username, password strin
 //SetAclCache sets a mix, granted option and expiration time.
 func (s *redisStore) SetACLRecord(ctx context.Context, username, topic, clientid string, acc int, granted string) error {
 	record := toACLRecord(username, topic, clientid, acc, s.h)
-	return s.setRecord(ctx, record, granted, s.authExpiration)
+	return s.setRecord(ctx, record, granted, s.aclExpiration)
 }
 
 func (s *redisStore) setRecord(ctx context.Context, record, granted string, expirationTime time.Duration) error {

--- a/go-auth.go
+++ b/go-auth.go
@@ -374,6 +374,8 @@ func setCache(authOpts map[string]string) {
 
 	var aclCacheSeconds int64 = 30
 	var authCacheSeconds int64 = 30
+	var authJitterSeconds int64 = 3
+	var aclJitterSeconds int64 = 3
 
 	if authCacheSec, ok := authOpts["auth_cache_seconds"]; ok {
 		authSec, err := strconv.ParseInt(authCacheSec, 10, 64)
@@ -384,12 +386,30 @@ func setCache(authOpts map[string]string) {
 		}
 	}
 
+	if authJitterSec, ok := authOpts["auth_jitter_seconds"]; ok {
+		authSec, err := strconv.ParseInt(authJitterSec, 10, 64)
+		if err == nil {
+			authJitterSeconds = authSec
+		} else {
+			log.Warningf("couldn't parse authJitterSeconds (err: %s), defaulting to %d", err, authJitterSeconds)
+		}
+	}
+
 	if aclCacheSec, ok := authOpts["acl_cache_seconds"]; ok {
 		aclSec, err := strconv.ParseInt(aclCacheSec, 10, 64)
 		if err == nil {
 			aclCacheSeconds = aclSec
 		} else {
 			log.Warningf("couldn't parse aclCacheSeconds (err: %s), defaulting to %d", err, aclCacheSeconds)
+		}
+	}
+
+	if aclJitterSec, ok := authOpts["acl_jitter_seconds"]; ok {
+		aclSec, err := strconv.ParseInt(aclJitterSec, 10, 64)
+		if err == nil {
+			aclJitterSeconds = aclSec
+		} else {
+			log.Warningf("couldn't parse aclJitterSeconds (err: %s), defaulting to %d", err, aclJitterSeconds)
 		}
 	}
 
@@ -439,6 +459,8 @@ func setCache(authOpts map[string]string) {
 				addresses,
 				time.Duration(authCacheSeconds)*time.Second,
 				time.Duration(aclCacheSeconds)*time.Second,
+				time.Duration(authJitterSeconds)*time.Second,
+				time.Duration(aclJitterSeconds)*time.Second,
 				refreshExpiration,
 			)
 
@@ -467,6 +489,8 @@ func setCache(authOpts map[string]string) {
 				db,
 				time.Duration(authCacheSeconds)*time.Second,
 				time.Duration(aclCacheSeconds)*time.Second,
+				time.Duration(authJitterSeconds)*time.Second,
+				time.Duration(aclJitterSeconds)*time.Second,
 				refreshExpiration,
 			)
 		}
@@ -475,6 +499,8 @@ func setCache(authOpts map[string]string) {
 		authPlugin.cache = cache.NewGoStore(
 			time.Duration(authCacheSeconds)*time.Second,
 			time.Duration(aclCacheSeconds)*time.Second,
+			time.Duration(authJitterSeconds)*time.Second,
+			time.Duration(aclJitterSeconds)*time.Second,
 			refreshExpiration,
 		)
 	}

--- a/go-auth.go
+++ b/go-auth.go
@@ -395,6 +395,11 @@ func setCache(authOpts map[string]string) {
 		}
 	}
 
+	if authJitterSeconds > authCacheSeconds {
+		authJitterSeconds = authCacheSeconds
+		log.Warningf("authJitterSeconds is larger than authCacheSeconds, defaulting to %d", authJitterSeconds)
+	}
+
 	if aclCacheSec, ok := authOpts["acl_cache_seconds"]; ok {
 		aclSec, err := strconv.ParseInt(aclCacheSec, 10, 64)
 		if err == nil {
@@ -411,6 +416,11 @@ func setCache(authOpts map[string]string) {
 		} else {
 			log.Warningf("couldn't parse aclJitterSeconds (err: %s), defaulting to %d", err, aclJitterSeconds)
 		}
+	}
+
+	if aclJitterSeconds > aclCacheSeconds {
+		aclJitterSeconds = aclCacheSeconds
+		log.Warningf("aclJitterSeconds is larger than aclCacheSeconds, defaulting to %d", aclJitterSeconds)
 	}
 
 	reset := false

--- a/go-auth.go
+++ b/go-auth.go
@@ -374,8 +374,8 @@ func setCache(authOpts map[string]string) {
 
 	var aclCacheSeconds int64 = 30
 	var authCacheSeconds int64 = 30
-	var authJitterSeconds int64 = 3
-	var aclJitterSeconds int64 = 3
+	var authJitterSeconds int64 = 0
+	var aclJitterSeconds int64 = 0
 
 	if authCacheSec, ok := authOpts["auth_cache_seconds"]; ok {
 		authSec, err := strconv.ParseInt(authCacheSec, 10, 64)


### PR DESCRIPTION
Port of https://github.com/jpmens/mosquitto-auth-plug/pull/315

Add a jitter to the expiration delay, which avoid lots of entry to expire at the same time. This could easily occur when the Mosquitto server is restarted: all clients get disconnected and will all reconnect quickly. This will cause a storm of lookups (can't avoid the first one, at least not without Redis). But without any jitter, every acl_cacheseconds a new lookup storm will happen.

This PR is based on #122 because otherwise a conflict will occur.