### PR TITLE
Retry on backend error

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,19 @@ auth_opt_log_file /var/log/mosquitto/mosquitto.log
 
 If `log_dest` or `log_file` are invalid, or if there's an error opening the file (e.g. no permissions), logging will default to `stderr`.
 
+#### Retry
+
+By default, if backend had an error (and no other backend granted access), an error is returned to Mosquitto.
+
+It's possible to enable retry, which will immediately retry all configured backends. This could be useful if the
+backend may be behind a load-balancer (like HTTP backend) and one instance may fail:
+
+```
+auth_opt_retry_count 2
+```
+
+The above example will do up to 2 retry (3 call in total) if backend had an error.
+
 #### Prefixes
 
 Though the plugin may have multiple backends enabled, there's a way to specify which backend must be used for a given user: prefixes. When enabled, `prefixes` allow to check if the username contains a predefined prefix in the form prefix_username and use the configured backend for that prefix. Options to enable and set prefixes are the following:

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ backend may be behind a load-balancer (like HTTP backend) and one instance may f
 auth_opt_retry_count 2
 ```
 
-The above example will do up to 2 retry (3 call in total) if backend had an error.
+The above example will do up to 2 retries (3 calls in total considering the original one) if the responsible backend had an error or was down while performing the check.
 
 #### Prefixes
 


### PR DESCRIPTION
Port of https://github.com/jpmens/mosquitto-auth-plug/pull/144

Allow to retry call to backend in case of error. This is useful if there are multiple backends behind a load-balancer and some backend are unhealthy (e.g. during canary deployment, where some backend use a new - bugged - version).

The default is to not retry, as this feature is not needed for every backend.

It's based on #120 because otherwise a conflict will occur. Since #120 contains lots of change, this PR should probably be only reviewed after #120 is merged (or only have a look at the 2nd commit).

This should be the last PR I made for this week :) Thanks for your works on this project, I hope all those PR won't give you too much work.