### PR TITLE
Avoid using 100% when using file backend

### DIFF
--- a/backends/files.go
+++ b/backends/files.go
@@ -93,8 +93,6 @@ func (o *Files) watchSignals() {
 				log.Debugln("Got SIGHUP, reloading files.")
 				o.loadFiles()
 			}
-		default:
-			// NO-OP
 		}
 	}
 }


### PR DESCRIPTION
The signal watched had a select{} with default clause inside a for{} loop. This cause the default clause to be executed in loop as fast as possible and use 100% CPU.

The following small code show the issue:
```golang
package main

import (
	"log"
	"os"
	"time"

	bes "github.com/iegomez/mosquitto-go-auth/backends"
	"github.com/sirupsen/logrus"
)

func main() {
	backend, err := bes.NewFiles(map[string]string{"password_path": "/dev/null"}, logrus.DebugLevel, nil)
	if err != nil {
		log.Fatal(err)
	}

	log.Printf("See me (PID = %d) using 100%% CPU :)", os.Getpid())
	time.Sleep(time.Minute)
        backend.Halt()
}

```


Using top, you will see that without this PR, the process will use 100% CPU.