### PR TITLE
Fix support for topic with whitespace

### DIFF
--- a/backends/files.go
+++ b/backends/files.go
@@ -195,32 +195,29 @@ func (o *Files) readAcls() (int, error) {
 			continue
 		}
 
-		//If we see a user line, change the current user.
-		if strings.Contains(line, "user") {
-			//Try to get username
-			lineArr := strings.Fields(line)
+		lineArr := strings.Fields(line)
 
+		switch lineArr[0] {
+		//If we see a user line, change the current user.
+		case "user":
 			//Check format
-			if len(lineArr) == 2 && lineArr[0] == "user" {
-				_, ok := o.Users[lineArr[1]]
+			if len(lineArr) >= 2 {
+				userName := strings.Join(lineArr[1:], " ")
+				_, ok := o.Users[userName]
 
 				//Check that user exists
 				if !ok {
-					log.Warnf("user %s doesn't exist, skipping acl", lineArr[1])
+					log.Warnf("user %s doesn't exist, skipping acl", userName)
 					continue
 				}
 
-				currentUser = lineArr[1]
+				currentUser = userName
 
 			} else {
 				return 0, errors.Errorf("Files backend error: wrong acl format at line %d", index)
 			}
-		} else if strings.Contains(line, "topic") {
-
-			//Split and check for read, write or empty (readwwrite) privileges.
-			lineArr := strings.Fields(line)
-
-			if (len(lineArr) == 2 || len(lineArr) == 3) && lineArr[0] == "topic" {
+		case "topic":
+			if len(lineArr) >= 2 {
 
 				var aclRecord = AclRecord{
 					Topic: "",
@@ -232,7 +229,7 @@ func (o *Files) readAcls() (int, error) {
 					aclRecord.Topic = lineArr[1]
 					aclRecord.Acc = MOSQ_ACL_READWRITE
 				} else {
-					aclRecord.Topic = lineArr[2]
+					aclRecord.Topic = strings.Join(lineArr[2:], " ")
 					if lineArr[1] == "read" {
 						aclRecord.Acc = MOSQ_ACL_READ
 					} else if lineArr[1] == "write" {
@@ -263,12 +260,8 @@ func (o *Files) readAcls() (int, error) {
 				return 0, errors.Errorf("Files backend error: wrong acl format at line %d", index)
 			}
 
-		} else if strings.Contains(line, "pattern") {
-
-			//Split and check for read, write or empty (readwwrite) privileges.
-			lineArr := strings.Fields(line)
-
-			if (len(lineArr) == 2 || len(lineArr) == 3) && lineArr[0] == "pattern" {
+		case "pattern":
+			if len(lineArr) >= 2 {
 
 				var aclRecord = AclRecord{
 					Topic: "",
@@ -280,7 +273,7 @@ func (o *Files) readAcls() (int, error) {
 					aclRecord.Topic = lineArr[1]
 					aclRecord.Acc = MOSQ_ACL_READWRITE
 				} else {
-					aclRecord.Topic = lineArr[2]
+					aclRecord.Topic = strings.Join(lineArr[2:], " ")
 					if lineArr[1] == "read" {
 						aclRecord.Acc = MOSQ_ACL_READ
 					} else if lineArr[1] == "write" {

--- a/test-files/acls
+++ b/test-files/acls
@@ -2,6 +2,9 @@ user test1
 topic write test/topic/1
 topic read test/topic/2
 topic readwrite readwrite/topic
+# topic read test/comment-are-ignored
+topic write test/user/topic/1
+topic implicit-readwrite/topic
 
 user test2
 topic read test/topic/+
@@ -9,8 +12,16 @@ topic read test/topic/+
 user test3
 topic read test/#
 
+# Username with whitespace are allowed.
+user    name with whitespace@and/other.charcater
+topic   read    test/whitespace in the topic
+
 user not_present
 topic read test/#
 
 pattern read test/%u
 pattern read test/%c
+pattern read test/pattern with whitespace/%u
+
+# It's not a typo to have line with only whitespace. It's to ensure parser ignore the line as empty
+     

--- a/test-files/passwords
+++ b/test-files/passwords
@@ -1,3 +1,4 @@
 test1:PBKDF2$sha512$100000$2WQHK5rjNN+oOT+TZAsWAw==$TDf4Y6J+9BdnjucFQ0ZUWlTwzncTjOOeE00W4Qm8lfPQyPCZACCjgfdK353jdGFwJjAf6vPAYaba9+z4GWK7Gg==
 test2:PBKDF2$sha512$100000$o513B9FfaKTL6xalU+UUwA==$mAUtjVg1aHkDpudOnLKUQs8ddGtKKyu+xi07tftd5umPKQKnJeXf1X7RpoL/Gj/ZRdpuBu5GWZ+NZ2rYyAsi1g==
 test3:PBKDF2$sha512$100000$gDJp1GiuxauYi6jM+aI+vw==$9Rn4GrsfUkpyXdqfN3COU4oKpy7NRiLkcyutQ7I3ki1I2oY8/fuBnu+3oPKOm8WkAlpOnuwvTMGvii5QIIKmWA==
+name with whitespace@and/other.charcater:PBKDF2$sha512$100000$5dgqhpwX9ucdYe4f9p74Dg==$cJTt3l0vdDZn53nnLxLPXzjv0zDuByhtIL7CjNIexySGXAJU6sApWUwcxqFG3FJLoY9ib547A0Z64X67t0Dtdw==


### PR DESCRIPTION
Fix for #154 with tests added and support for whitespace in topic and username.

It still do not work with topic (or username) that have multiple consecutive spaces (like user "my      username").

Supporting them make core more complex and/or require a 3rd party library (like strtok implementation to copy code logic that Mosquitto do). Since multiple consecutive spaces is topic or username seems a really edge case, I think we can kept a simpler code without 3rd party library and don't support this case. 