### PR TITLE
Add 'tini' as init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN export PATH=$PATH:/usr/local/go/bin && export CGO_CFLAGS="-I/usr/local/inclu
 FROM debian:stable-slim
 
 #Get mosquitto dependencies.
-RUN apt-get update && apt-get install -y libwebsockets8 libc-ares2 openssl uuid
+RUN apt-get update && apt-get install -y libwebsockets8 libc-ares2 openssl uuid tini
 
 #Setup mosquitto env.
 RUN mkdir -p /var/lib/mosquitto /var/log/mosquitto 
@@ -64,4 +64,5 @@ COPY --from=builder /usr/local/sbin/mosquitto /usr/sbin/mosquitto
 #Expose tcp and websocket ports as defined at mosquitto.conf (change accordingly).
 EXPOSE 1883 1884
 
-ENTRYPOINT ["sh", "-c", "/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf" ]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD [ "/usr/sbin/mosquitto" ,"-c", "/etc/mosquitto/mosquitto.conf" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir mosquitto-go-auth && \
 FROM debian:stable-slim
 
 #Get mosquitto dependencies.
-RUN apt-get update && apt-get install -y libwebsockets8 libc-ares2 openssl uuid
+RUN apt-get update && apt-get install -y libwebsockets8 libc-ares2 openssl uuid tini
 
 #Setup mosquitto env.
 RUN mkdir -p /var/lib/mosquitto /var/log/mosquitto
@@ -67,4 +67,5 @@ COPY --from=builder /usr/local/sbin/mosquitto /usr/sbin/mosquitto
 #Expose tcp and websocket ports as defined at mosquitto.conf (change accordingly).
 EXPOSE 1883 1884
 
-ENTRYPOINT ["sh", "-c", "/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf" ]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD [ "/usr/sbin/mosquitto" ,"-c", "/etc/mosquitto/mosquitto.conf" ]


### PR DESCRIPTION
A lot of containers try to avoid using `shell` for the ENTRYPOINT due to issues with escaping characters and not always handling signals very well. Many use [tini](https://github.com/krallin/tini#why-tini) as a way to handle this.

This is configured so that it is also easy to replace CMD with your own value without affecting the init.