### PR TITLE
Bump mosquitto version to 2.0.12

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yml
+++ b/.github/workflows/build_and_push_docker_images.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 env:
   MOSQUITTO_VERSION_1: 1.6.14
-  MOSQUITTO_VERSION_2: 2.0.9
+  MOSQUITTO_VERSION_2: 2.0.12
   MOSQUITTO_VERSION_SUFFIX: -mosquitto_
   DOCKERFILE_MOSQUITTO_VERSION: 1.6.14
   DOCKERHUB_REPO: mosquitto-go-auth
@@ -18,7 +18,7 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
-      - 
+      -
         name: Set Mosquitto version
         run: sed -i 's/ARG MOSQUITTO_VERSION=${{ env.DOCKERFILE_MOSQUITTO_VERSION }}/ARG MOSQUITTO_VERSION=${{ env.MOSQUITTO_VERSION_1 }}/' Dockerfile
       -
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
-      - 
+      -
         name: Set Mosquitto version
         run: sed -i 's/ARG MOSQUITTO_VERSION=${{ env.DOCKERFILE_MOSQUITTO_VERSION }}/ARG MOSQUITTO_VERSION=${{ env.MOSQUITTO_VERSION_2 }}/' Dockerfile
       -
@@ -69,7 +69,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
31.8-21 version 2.0.12 was released: https://mosquitto.org/blog/

this PR just bumps the version of mosquitto used to build and publish dockerimages