### PR TITLE
Add oauth2/openid-connect backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,13 +1561,17 @@ which must return a json similar to
     "sub": "<username>",
     "mqtt": {
         "topics": {
-            "read": ["/test/#", "/test/read/#],
-            "write": ["/test/#","/test/write/#]
+            "read": ["/test/#", "/test2/read/#],
+            "subscribe": ["/test/#", "/test2/read/#],
+            "write": ["/test/#","/test/write/#],
+            "deny": ["/deny0","/deny/#"],
         },
         "superuser": false
     }
 }
 ```
+The values in are used to check `MOSQ_ACL_NONE`, `MOSQ_ACL_READ`, `MOSQ_ACL_WRITE`, `MOSQ_ACL_READWRITE`,
+`MOSQ_ACL_SUBSCRIBE`, `MOSQ_ACL_DENY` which are defined in `backends/constants/constants.go`.
 
 To use client credentials pass the `client_id` and `client_secret` to mosquitto as the username and password respectively.
 

--- a/README.md
+++ b/README.md
@@ -1580,9 +1580,9 @@ To  use the access token pass it to mosquitto as the username and use the passwo
 The following `auth_opt_` options are supported
 
 | Option           	   | default |  Mandatory  | Meaning					  						   |
-| ---------------------| ------- | :---------: | ----------------------------------------------------- |
+| ---------------------|---------| :---------: | ----------------------------------------------------- |
 | oauth_cache_duration |         | Y           | Duration in seconds after which a<br>request to oauth_userinfo_url is<br>performed to update users access right |
-| oauth_scopes         | all     | N           | Parameter is passed in request to<br>oauth_userinfo_url request<br>to obtain optional scopes |
+| oauth_scopes         |         | N           | Parameter is passed in request to<br>oauth_userinfo_url request<br>to obtain optional scopes |
 | oauth_token_url      |         | Y           | openid-connect Token Endpoint                         |
 | oauth_userinfo_url   |         | Y           | openid-connect Userinfo Endpoint                      |
 

--- a/README.md
+++ b/README.md
@@ -1604,6 +1604,7 @@ mosquitto_sub --host localhost --port 1883 --id oauthbearer_mosquitto_sub -V mqt
   --topic "/test/test_topic" --username "${TOKEN}" -P "oauthbearer_empty_password" 
 ```
 
+A minimal example of using mosquitto with this plugin and keycloak can be found [here](https://github.com/tilmann-bartsch/mqtt-oauth2-test).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1571,7 +1571,7 @@ which must return a json similar to
 
 To use client credentials pass the `client_id` and `client_secret` to mosquitto as the username and password respectively.
 
-To  use the access token pass it to mosquitto as the username and use the password `authbearer_empty_password` since mosquitto doesn't allow empty passwords.
+To  use the access token pass it to mosquitto as the username and use the password `oauthbearer_empty_password` since mosquitto doesn't allow empty passwords.
 
 The following `auth_opt_` options are supported
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These are the backends that this plugin implements right now:
 * Custom (experimental)
 * gRPC
 * Javascript interpreter
+* Oauth2
 
 **Every backend offers user, superuser and acl checks, and include proper tests.**
 
@@ -50,7 +51,7 @@ Please open an issue with the `feature` or `enhancement` tag to request new back
 	- [Log level](#log-level)
 	- [Prefixes](#prefixes)
 	- [Backend options](#backend-options)
-    - [Registering checks](#registering-checks)
+	- [Registering checks](#registering-checks)
 - [Files](#files)
 	- [Passwords file](#passwords-file)
 	- [ACL file](#acl-file)
@@ -81,6 +82,8 @@ Please open an issue with the `feature` or `enhancement` tag to request new back
 	- [Testing gRPC](#testing-grpc)
 - [Javascript](#javascript)
 	- [Testing Javascript](#testing-javascript)
+- [Oauth2](#oauth2)
+	- [Console Clients](#console-clients) 
 - [Using with LoRa Server](#using-with-lora-server)
 - [Docker](#docker)
 	- [Prebuilt images](#prebuilt-images)
@@ -1526,6 +1529,78 @@ Notice the `password` will be passed to the script as given by `mosquitto`, leav
 #### Testing Javascript
 
 This backend has no special requirements as `javascript` test files are provided to test different scenarios.
+
+### Oauth2
+
+The `oauth2` backend allows mosquitto to authenticate and authorize a client via an oauth2/openid-connect authorization server. Clients can either
+ - hand over a `client_id` and a `client_secret` ([client_credentials-oauth2-specification](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)), or 
+ - pass an `access_token` ([access_token-oauth2-specification](https://datatracker.ietf.org/doc/html/rfc6749#section-1.4))
+
+If mosquitto receives a `client_id` and `client_secret` it uses them to obtain an `access_token` from the authorization server before the old `access_token` expires with the following request
+```
+POST <auth_opt_oauth_token_url> HTTP/1.1
+Host: localhost
+Authorization: Basic dGVzdF9jbGllbnRfaWQ6dGVzdF9jbGllbnRfc2VjcmV0
+Content-Type: application/x-www-form-urlencoded
+grant_type=client_credentials
+```
+and expecting a response of the form
+```
+{"access_token":"<access_token>", "expires_in": 300, ...}
+```
+
+The authentication is then done by using the available `acces_token` by requesting
+```
+GET <auth_opt_oauth_userinfo_url> HTTP/1.1
+Host: localhost
+Authorization: Bearer access_token
+```
+which must return a json similar to
+```
+{
+    "sub": "<username>",
+    "mqtt": {
+        "topics": {
+            "read": ["/test/#", "/test/read/#],
+            "write": ["/test/#","/test/write/#]
+        },
+        "superuser": false
+    }
+}
+```
+
+To use client credentials pass the `client_id` and `client_secret` to mosquitto as the username and password respectively.
+
+To  use the access token pass it to mosquitto as the username and use the password `authbearer_empty_password` since mosquitto doesn't allow empty passwords.
+
+The following `auth_opt_` options are supported
+
+| Option           	   | default |  Mandatory  | Meaning					  						   |
+| ---------------------| ------- | :---------: | ----------------------------------------------------- |
+| oauth_cache_duration |         | Y           | Duration in seconds after which a<br>request to oauth_userinfo_url is<br>performed to update users access right |
+| oauth_scopes         | all     | N           | Parameter is passed in request to<br>oauth_userinfo_url request<br>to obtain optional scopes |
+| oauth_token_url      |         | Y           | openid-connect Token Endpoint                         |
+| oauth_userinfo_url   |         | Y           | openid-connect Userinfo Endpoint                      |
+
+#### Console Clients
+If the authorization server is running use the following commands to test the plugin.
+##### client credentials
+```
+mosquitto_sub --host localhost --port 1883 --id clientcredentials_mosquitto_sub -V mqttv5 \
+  --topic /test/test_topic --username <client_id> -P <client_secret>
+```
+##### access token
+```
+basic_auth=$(printf "<client_id>:<client_secret>" | base64)
+TOKEN=$(curl --location --request POST "<oauth2_token_endpoint>" --header "Authorization: Basic ${basic_auth}"
+  --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=client_credentials' \\
+    | jq -r ".access_token")
+
+mosquitto_sub --host localhost --port 1883 --id oauthbearer_mosquitto_sub -V mqttv5 \
+  --topic "/test/test_topic" --username "${TOKEN}" -P "oauthbearer_empty_password" 
+```
+
+
 
 
 ### Using with LoRa Server

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -212,7 +212,7 @@ func (b *Backends) addBackends(authOpts map[string]string, logLevel log.Level, b
 				log.Fatalf("Backend register error: couldn't initialize %s backend with error %s.", bename, err)
 			} else {
 				log.Infof("Backend registered: %s", beIface.GetName())
-				b.backends[oauth2Backend] = beIface.(Oauth2)
+				b.backends[oauth2Backend] = beIface.(*Oauth2)
 			}
 		case pluginBackend:
 			beIface, err = NewCustomPlugin(authOpts, logLevel)

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -44,6 +44,7 @@ const (
 	pluginBackend   = "plugin"
 	grpcBackend     = "grpc"
 	jsBackend       = "js"
+	oauth2Backend   = "oauth2"
 
 	// checks
 	aclCheck       = "acl"
@@ -67,6 +68,7 @@ var allowedBackendsOptsPrefix = map[string]string{
 	pluginBackend:   "plugin",
 	grpcBackend:     "grpc",
 	jsBackend:       "js",
+	oauth2Backend:   "oauth2",
 }
 
 // Initialize sets general options, tries to build the backends and register their checkers.
@@ -203,6 +205,14 @@ func (b *Backends) addBackends(authOpts map[string]string, logLevel log.Level, b
 			} else {
 				log.Infof("Backend registered: %s", beIface.GetName())
 				b.backends[jsBackend] = beIface.(*Javascript)
+			}
+		case oauth2Backend:
+			beIface, err = NewOauth2(authOpts, logLevel)
+			if err != nil {
+				log.Fatalf("Backend register error: couldn't initialize %s backend with error %s.", bename, err)
+			} else {
+				log.Infof("Backend registered: %s", beIface.GetName())
+				b.backends[oauth2Backend] = beIface.(Oauth2)
 			}
 		case pluginBackend:
 			beIface, err = NewCustomPlugin(authOpts, logLevel)

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -258,7 +258,7 @@ func (o *Oauth2) getUserInfo(client *http.Client) (*UserInfo, error) {
 			log.Debug(err)
 			return nil, err
 		}
-		log.Debugf("Using Token: %s", token)
+		log.Debugf("Using Token: %s", token.AccessToken)
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -251,7 +251,15 @@ func (o *Oauth2) createUserWithToken(accessToken, clientid string) (bool, error)
 
 func (o *Oauth2) getUserInfo(client *http.Client) (*UserInfo, error) {
 	req, _ := http.NewRequest("GET", o.userInfoURL, nil)
-	log.Debugf("Performing request: %s %s:%s%s", req.Method, req.URL.Scheme, req.URL.Host, req.URL.Path)
+	log.Debugf("Performing request: %s %s://%s%s", req.Method, req.URL.Scheme, req.URL.Host, req.URL.Path)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		token, err := client.Transport.(*go_oauth2.Transport).Source.Token()
+		if err != nil {
+			log.Debug(err)
+			return nil, err
+		}
+		log.Debugf("Using Token: %s", token)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Debug(err)
@@ -272,8 +280,6 @@ func (o *Oauth2) getUserInfo(client *http.Client) (*UserInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debugf("hey")
 
 	return &info, nil
 }

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -57,14 +57,12 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 	var oauth2 = &Oauth2{}
 	oauth2.version = "1.0.0"
 
-	placedOpts := ""
 	missingOpts := ""
 	oauth2Ok := true
 
 	tokenUrl, ok := authOpts["oauth_token_url"]
 	if ok {
 		oauth2.tokenUrl = tokenUrl
-		placedOpts += "oauth_token_url=" + tokenUrl + "\n"
 	} else {
 		oauth2Ok = false
 		missingOpts += " oauth_token_url"
@@ -79,7 +77,6 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 
 	if cacheDurationSeconds, ok := authOpts["oauth_cache_duration"]; ok {
 		if durationInt, err := strconv.Atoi(cacheDurationSeconds); err == nil {
-			placedOpts += "oauth_cache_duration=" + cacheDurationSeconds + "\n"
 			oauth2.cacheDuration = time.Duration(durationInt) * time.Second
 		} else {
 			log.Errorf("unable to parse cacheDurationSeconds: %s", err)
@@ -90,7 +87,6 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 	}
 
 	if scopes, ok := authOpts["oauth_scopes"]; ok {
-		placedOpts += "oauth_scopes=" + scopes + "\n"
 		oauth2.scopesSplit = strings.Split(strings.Replace(scopes, " ", "", -1), ",")
 	} else {
 		log.Infof("no scopes where specified, using scope `all`")
@@ -99,9 +95,7 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 
 	oauth2.userCache = make(map[string]userState)
 
-	if oauth2Ok {
-		log.Infof("OAuth Plugin initialized with configurations\n" + placedOpts)
-	} else {
+	if !oauth2Ok {
 		return oauth2, errors.Errorf("Oauth2 backend error: missing remote options: %s", missingOpts)
 	}
 

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -90,8 +90,8 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 	if scopes, ok := authOpts["oauth_scopes"]; ok {
 		oauth2.scopesSplit = strings.Split(strings.Replace(scopes, " ", "", -1), ",")
 	} else {
-		log.Infof("no scopes where specified, using scope `all`")
-		oauth2.scopesSplit = []string{"all"}
+		log.Infof("no scopes where specified")
+		oauth2.scopesSplit = []string{}
 	}
 
 	oauth2.userCache = make(map[string]userState)

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -21,6 +21,8 @@ type userState struct {
 	superuser         bool
 	readTopics        []string
 	writeTopics       []string
+	subscribeTopics   []string
+	denyTopics        []string
 	lastUserInfoUpate time.Time
 	createdAt         time.Time
 	updatedAt         time.Time
@@ -29,31 +31,32 @@ type userState struct {
 }
 
 type UserInfo struct {
-	sub  string `json:"sub"`
+	Sub  string `json:"sub"`
 	MQTT struct {
 		Topics struct {
-			Read  []string `json:"read"`
-			Write []string `json:"write"`
+			Read      []string `json:"read"`
+			Write     []string `json:"write"`
+			Subscribe []string `json:"subscribe"`
+			Deny      []string `json:"deny"`
 		} `json:"topics"`
 		Superuser bool `json:"superuser"`
 	} `json:"mqtt"`
 }
 
 type Oauth2 struct {
-	oauth2Config            go_oauth2.Config
-	clientcredentialsConfig go_clientcredentials.Config
-	tokenUrl                string
-	userInfoURL             string
-	userCache               map[string]userState
-	cacheDuration           time.Duration
-	version                 string
-	scopesSplit             []string
+	tokenUrl      string
+	userInfoURL   string
+	userCache     map[string]userState
+	cacheDuration time.Duration
+	version       string
+	scopesSplit   []string
 }
 
 func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) {
 	log.SetLevel(logLevel)
 
 	var oauth2 = &Oauth2{}
+	oauth2.version = "1.0.0"
 
 	placedOpts := ""
 	missingOpts := ""
@@ -66,15 +69,6 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 	} else {
 		oauth2Ok = false
 		missingOpts += " oauth_token_url"
-	}
-
-	oauth2.oauth2Config = go_oauth2.Config{
-		Scopes:      oauth2.scopesSplit,
-		RedirectURL: "",
-		Endpoint: go_oauth2.Endpoint{
-			TokenURL: tokenUrl,
-			AuthURL:  "",
-		},
 	}
 
 	if userInfoURL, ok := authOpts["oauth_userinfo_url"]; ok {
@@ -116,9 +110,6 @@ func NewOauth2(authOpts map[string]string, logLevel log.Level) (*Oauth2, error) 
 }
 
 func (o *Oauth2) GetUser(username, password, clientid string) (bool, error) {
-	// Get token for the credentials and verify the user
-	log.Debugf("Checking user with oauth plugin.")
-
 	if password == "oauthbearer_empty_password" {
 		return o.createUserWithToken(username, clientid)
 	} else {
@@ -135,26 +126,9 @@ func (o *Oauth2) GetSuperuser(username string) (bool, error) {
 		return false, fmt.Errorf("no entry in user cache for user %s", username)
 	}
 
-	if o.cacheIsValid(&cache) {
-		log.Debugf("using cached userinfo to authorize")
-	} else {
-		log.Debugf("update userinfo using authorization server %s", o.userInfoURL)
-
-		if !cache.token.Valid() {
-			log.Warningf("Token for user %s invalid. Try to refresh.", username)
-		}
-
-		info, err := o.getUserInfo(cache.client)
-
-		if err != nil {
-			log.Errorf("Failed to receive UserInfo for user %s: %s", username, err)
-			return false, err
-		}
-
-		cache.superuser = info.MQTT.Superuser
-		cache.readTopics = info.MQTT.Topics.Read
-		cache.writeTopics = info.MQTT.Topics.Write
-		cache.updatedAt = time.Now()
+	err := o.updateCache(&cache)
+	if err != nil {
+		return false, err
 	}
 
 	log.Debugf("Check for superuser was %t", cache.superuser)
@@ -163,35 +137,18 @@ func (o *Oauth2) GetSuperuser(username string) (bool, error) {
 }
 
 func (o *Oauth2) CheckAcl(username, topic, clientid string, acc int32) (bool, error) {
-	// Function that checks if the user has the right to access to an address
+	// Function that checks if the user has the right to access a topic
 	log.Debugf("Checking if user %s is allowed to access topic %s with access %d.", username, topic, acc)
 
 	cache, ok := o.userCache[username]
 	if !ok {
-		return false, fmt.Errorf("Have no entry in user cache for user %s", username)
+		return false, fmt.Errorf("no entry in user cache for user %s", username)
 	}
 
-	if o.cacheIsValid(&cache) {
-		log.Debugf("using cached userinfo to authorize")
-	} else {
-		log.Debugf("update userinfo using authorization server %s", o.userInfoURL)
-
-		info, err := o.getUserInfo(cache.client)
-
-		if err != nil {
-			log.Errorf("Failed to receive UserInfo for user %s: %s", username, err)
-			return false, err
-		}
-
-		cache.superuser = info.MQTT.Superuser
-		cache.readTopics = info.MQTT.Topics.Read
-		cache.writeTopics = info.MQTT.Topics.Write
-		cache.updatedAt = time.Now()
+	err := o.updateCache(&cache)
+	if err != nil {
+		return false, err
 	}
-
-	log.Debugf("  user is superuser: %t", cache.superuser)
-	log.Debugf("  topics with read permission %s", cache.readTopics)
-	log.Debugf("  topics with write permission %s", cache.writeTopics)
 
 	res := o.checkAccessToTopic(topic, acc, &cache, username, clientid)
 	log.Debugf("ACL check was %t", res)
@@ -199,28 +156,59 @@ func (o *Oauth2) CheckAcl(username, topic, clientid string, acc int32) (bool, er
 }
 
 func (o *Oauth2) GetName() string {
-	return "OAuth Plugin " + o.version
+	return "OAuth2 backend, version " + o.version
 }
 
 func (o *Oauth2) Halt() {
 	// Do whatever cleanup is needed.
 }
 
+func (o *Oauth2) updateCache(cache *userState) error {
+
+	if o.cacheIsValid(cache) {
+		log.Debugf("using cached userinfo for user '%s' to authorize", cache.username)
+	} else {
+		log.Debugf("update userinfo for user '%s' using authorization server %s", cache.username, o.userInfoURL)
+
+		info, err := o.getUserInfo(cache.client)
+
+		if err != nil {
+			log.Errorf("Failed to receive UserInfo for user %s: %s", cache.username, err)
+			return err
+		}
+
+		cache.superuser = info.MQTT.Superuser
+		cache.readTopics = info.MQTT.Topics.Read
+		cache.writeTopics = info.MQTT.Topics.Write
+		cache.subscribeTopics = info.MQTT.Topics.Subscribe
+		cache.denyTopics = info.MQTT.Topics.Deny
+		cache.updatedAt = time.Now()
+	}
+
+	log.Debugf("  user is superuser: %t", cache.superuser)
+	log.Debugf("  topics with read permission: %s", cache.readTopics)
+	log.Debugf("  topics with write permission: %s", cache.writeTopics)
+	log.Debugf("  topics with subscribe permission: %s", cache.subscribeTopics)
+	log.Debugf("  denied topics: %s", cache.denyTopics)
+
+	return nil
+}
+
 func (o *Oauth2) createUserWithCredentials(username, password, clientid string) (bool, error) {
-	o.clientcredentialsConfig = go_clientcredentials.Config{
+	clientcredentialsConfig := go_clientcredentials.Config{
 		ClientID:     username,
 		ClientSecret: password,
 		TokenURL:     o.tokenUrl,
 	}
 
-	token, err := o.clientcredentialsConfig.Token(context.Background())
+	token, err := clientcredentialsConfig.Token(context.Background())
 
 	if err != nil {
 		log.Println(err)
 		return false, err
 	}
 
-	clientcredentialsClient := o.clientcredentialsConfig.Client(context.Background())
+	clientcredentialsClient := clientcredentialsConfig.Client(context.Background())
 
 	o.userCache[username] = userState{
 		username:  username,
@@ -240,7 +228,16 @@ func (o *Oauth2) createUserWithToken(accessToken, clientid string) (bool, error)
 		TokenType:   "Bearer",
 	}
 
-	client := o.oauth2Config.Client(context.Background(), token)
+	oauth2Config := go_oauth2.Config{
+		Scopes:      o.scopesSplit,
+		RedirectURL: "",
+		Endpoint: go_oauth2.Endpoint{
+			TokenURL: o.tokenUrl,
+			AuthURL:  "",
+		},
+	}
+
+	client := oauth2Config.Client(context.Background(), token)
 
 	info, err := o.getUserInfo(client)
 
@@ -250,14 +247,16 @@ func (o *Oauth2) createUserWithToken(accessToken, clientid string) (bool, error)
 	}
 
 	o.userCache[accessToken] = userState{
-		username:    accessToken,
-		superuser:   info.MQTT.Superuser,
-		createdAt:   time.Now(),
-		updatedAt:   time.Now(),
-		readTopics:  info.MQTT.Topics.Read,
-		writeTopics: info.MQTT.Topics.Write,
-		client:      client,
-		token:       token,
+		username:        accessToken,
+		superuser:       info.MQTT.Superuser,
+		createdAt:       time.Now(),
+		updatedAt:       time.Now(),
+		readTopics:      info.MQTT.Topics.Read,
+		writeTopics:     info.MQTT.Topics.Write,
+		subscribeTopics: info.MQTT.Topics.Subscribe,
+		denyTopics:      info.MQTT.Topics.Deny,
+		client:          client,
+		token:           token,
 	}
 
 	return true, err
@@ -284,33 +283,48 @@ func (o *Oauth2) getUserInfo(client *http.Client) (*UserInfo, error) {
 func (o *Oauth2) checkAccessToTopic(topic string, acc int32, cache *userState, username string, clientid string) bool {
 	log.Debugf("Check for acl level %d", acc)
 
-	// check read access
+	if acc == MOSQ_ACL_NONE {
+		resRead := !o.isTopicInList(cache.readTopics, topic, username, clientid)
+		resWrite := !o.isTopicInList(cache.writeTopics, topic, username, clientid)
+		resSubscribe := !o.isTopicInList(cache.subscribeTopics, topic, username, clientid)
+		resDeny := !o.isTopicInList(cache.denyTopics, topic, username, clientid)
+		res := resRead && resWrite && resSubscribe && resDeny
+		log.Debugf("ACL for none was %t", res)
+		return res
+	}
+
 	if acc == MOSQ_ACL_READ {
 		res := o.isTopicInList(cache.readTopics, topic, username, clientid)
 		log.Debugf("ACL for read was %t", res)
 		return res
 	}
 
-	// check subscribe access
-	if acc == MOSQ_ACL_SUBSCRIBE {
-		res := o.isTopicInList(cache.readTopics, topic, username, clientid)
-		log.Debugf("ACL for read was %t", res)
-		return res
-	}
-
-	// check write
 	if acc == MOSQ_ACL_WRITE {
 		res := o.isTopicInList(cache.writeTopics, topic, username, clientid)
 		log.Debugf("ACL for write was %t", res)
 		return res
 	}
 
-	// check for readwrite
 	if acc == MOSQ_ACL_READWRITE {
-		res := o.isTopicInList(cache.readTopics, topic, username, clientid) && o.isTopicInList(cache.writeTopics, topic, username, clientid)
+		resRead := o.isTopicInList(cache.readTopics, topic, username, clientid)
+		resWrite := o.isTopicInList(cache.writeTopics, topic, username, clientid)
+		res := resRead && resWrite
 		log.Debugf("ACL for readwrite was %t", res)
 		return res
 	}
+
+	if acc == MOSQ_ACL_SUBSCRIBE {
+		res := o.isTopicInList(cache.subscribeTopics, topic, username, clientid)
+		log.Debugf("ACL for subscribe was %t", res)
+		return res
+	}
+
+	if acc == MOSQ_ACL_DENY {
+		res := o.isTopicInList(cache.denyTopics, topic, username, clientid)
+		log.Debugf("ACL for deny was %t", res)
+		return res
+	}
+
 	return false
 }
 

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -107,7 +107,7 @@ func (o *Oauth2) GetUser(username, password, clientid string) (bool, error) {
 	if password == "oauthbearer_empty_password" {
 		return o.createUserWithToken(username, clientid)
 	} else {
-		return o.createUserWithCredentials(username, password, clientid)
+		return o.createUserWithClientCredentials(username, password, clientid)
 	}
 }
 
@@ -190,11 +190,12 @@ func (o *Oauth2) updateCache(cache *userState) error {
 	return nil
 }
 
-func (o *Oauth2) createUserWithCredentials(username, password, clientid string) (bool, error) {
+func (o *Oauth2) createUserWithClientCredentials(username, password, clientid string) (bool, error) {
 	clientcredentialsConfig := go_clientcredentials.Config{
 		ClientID:     username,
 		ClientSecret: password,
 		TokenURL:     o.tokenUrl,
+		Scopes:       o.scopesSplit,
 	}
 
 	clientcredentialsClient := clientcredentialsConfig.Client(context.Background())

--- a/backends/oauth2.go
+++ b/backends/oauth2.go
@@ -1,0 +1,335 @@
+package backends
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/iegomez/mosquitto-go-auth/backends/topics"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	go_oauth2 "golang.org/x/oauth2"
+	go_clientcredentials "golang.org/x/oauth2/clientcredentials"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type userState struct {
+	username          string
+	superuser         bool
+	readTopics        []string
+	writeTopics       []string
+	lastUserInfoUpate time.Time
+	createdAt         time.Time
+	updatedAt         time.Time
+	client            *http.Client
+	token             *go_oauth2.Token
+}
+
+type UserInfo struct {
+	sub  string `json:"sub"`
+	MQTT struct {
+		Topics struct {
+			Read  []string `json:"read"`
+			Write []string `json:"write"`
+		} `json:"topics"`
+		Superuser bool `json:"superuser"`
+	} `json:"mqtt"`
+}
+
+type Oauth2 struct {
+	oauth2Config            go_oauth2.Config
+	clientcredentialsConfig go_clientcredentials.Config
+	tokenUrl                string
+	userInfoURL             string
+	userCache               map[string]userState
+	cacheDuration           time.Duration
+	version                 string
+	scopesSplitted          []string
+}
+
+func NewOauth2(authOpts map[string]string, logLevel log.Level) (Oauth2, error) {
+	log.SetLevel(logLevel)
+
+	var oauth2 = Oauth2{}
+
+	placedOpts := ""
+	missingOpts := ""
+	oauth2Ok := true
+
+	tokenUrl, ok := authOpts["oauth_token_url"]
+	if ok {
+		oauth2.tokenUrl = tokenUrl
+		placedOpts += "oauth_token_url=" + tokenUrl + "\n"
+	} else {
+		oauth2Ok = false
+		missingOpts += " oauth_token_url"
+	}
+
+	oauth2.oauth2Config = go_oauth2.Config{
+		Scopes:      oauth2.scopesSplitted,
+		RedirectURL: "",
+		Endpoint: go_oauth2.Endpoint{
+			TokenURL: tokenUrl,
+			AuthURL:  "",
+		},
+	}
+
+	if userInfoURL, ok := authOpts["oauth_userinfo_url"]; ok {
+		placedOpts += "oauth_userinfo_url=" + userInfoURL + "\n"
+		oauth2.userInfoURL = userInfoURL
+	} else {
+		oauth2Ok = false
+		missingOpts += " oauth_userinfo_url"
+	}
+
+	if cacheDurationSeconds, ok := authOpts["oauth_cache_duration"]; ok {
+		if durationInt, err := strconv.Atoi(cacheDurationSeconds); err == nil {
+			placedOpts += "oauth_cache_duration=" + cacheDurationSeconds + "\n"
+			oauth2.cacheDuration = time.Duration(durationInt) * time.Second
+		} else {
+			log.Errorf("unable to parse cacheDurationSeconds: %s", err)
+		}
+	} else {
+		oauth2Ok = false
+		missingOpts += " oauth_cache_duration"
+	}
+
+	if scopes, ok := authOpts["oauth_scopes"]; ok {
+		placedOpts += "oauth_scopes=" + scopes + "\n"
+		oauth2.scopesSplitted = strings.Split(strings.Replace(scopes, " ", "", -1), ",")
+	} else {
+		log.Infof("no scopes where specified, using scope `all`")
+		oauth2.scopesSplitted = []string{"all"}
+	}
+
+	oauth2.userCache = make(map[string]userState)
+
+	if oauth2Ok {
+		log.Infof("OAuth Plugin initialized with configurations\n" + placedOpts)
+	} else {
+		return oauth2, errors.Errorf("Oauth2 backend error: missing remote options: %s", missingOpts)
+	}
+
+	return oauth2, nil
+}
+
+func (o Oauth2) GetUser(username, password, clientid string) (bool, error) {
+	// Get token for the credentials and verify the user
+	log.Debugf("Checking user with oauth plugin.")
+
+	if password == "oauthbearer_empty_password" {
+		return o.createUserWithToken(username, clientid)
+	} else {
+		return o.createUserWithCredentials(username, password, clientid)
+	}
+}
+
+func (o Oauth2) GetSuperuser(username string) (bool, error) {
+	// Function that checks if the user has admin privilies
+	log.Debugf("Checking if user %s is a superuser.", username)
+
+	cache, ok := o.userCache[username]
+	if !ok {
+		return false, fmt.Errorf("no entry in user cache for user %s", username)
+	}
+
+	if o.cacheIsValid(&cache) {
+		log.Debugf("using cached userinfo to authorize")
+	} else {
+		log.Debugf("update userinfo using authorization server %s", o.userInfoURL)
+
+		if !cache.token.Valid() {
+			log.Warningf("Token for user %s invalid. Try to refresh.", username)
+		}
+
+		info, err := o.getUserInfo(cache.client)
+
+		if err != nil {
+			log.Errorf("Failed to receive UserInfo for user %s: %s", username, err)
+			return false, err
+		}
+
+		cache.superuser = info.MQTT.Superuser
+		cache.readTopics = info.MQTT.Topics.Read
+		cache.writeTopics = info.MQTT.Topics.Write
+		cache.updatedAt = time.Now()
+	}
+
+	log.Debugf("Check for superuser was %t", cache.superuser)
+	o.userCache[username] = cache
+	return cache.superuser, nil
+}
+
+func (o Oauth2) CheckAcl(username, topic, clientid string, acc int32) (bool, error) {
+	// Function that checks if the user has the right to access to an address
+	log.Debugf("Checking if user %s is allowed to access topic %s with access %d.", username, topic, acc)
+
+	cache, ok := o.userCache[username]
+	if !ok {
+		return false, fmt.Errorf("Have no entry in user cache for user %s", username)
+	}
+
+	if o.cacheIsValid(&cache) {
+		log.Debugf("using cached userinfo to authorize")
+	} else {
+		log.Debugf("update userinfo using authorization server %s", o.userInfoURL)
+
+		info, err := o.getUserInfo(cache.client)
+
+		if err != nil {
+			log.Errorf("Failed to receive UserInfo for user %s: %s", username, err)
+			return false, err
+		}
+
+		cache.superuser = info.MQTT.Superuser
+		cache.readTopics = info.MQTT.Topics.Read
+		cache.writeTopics = info.MQTT.Topics.Write
+		cache.updatedAt = time.Now()
+	}
+
+	log.Debugf("  user is superuser: %t", cache.superuser)
+	log.Debugf("  topics with read permission %s", cache.readTopics)
+	log.Debugf("  topics with write permission %s", cache.writeTopics)
+
+	res := o.checkAccessToTopic(topic, acc, &cache, username, clientid)
+	log.Debugf("ACL check was %t", res)
+	return res, nil
+}
+
+func (o Oauth2) GetName() string {
+	return "OAuth Plugin " + o.version
+}
+
+func (o Oauth2) Halt() {
+	// Do whatever cleanup is needed.
+}
+
+func (o Oauth2) createUserWithCredentials(username, password, clientid string) (bool, error) {
+	o.clientcredentialsConfig = go_clientcredentials.Config{
+		ClientID:     username,
+		ClientSecret: password,
+		TokenURL:     o.tokenUrl,
+	}
+
+	token, err := o.clientcredentialsConfig.Token(context.Background())
+
+	if err != nil {
+		log.Println(err)
+		return false, err
+	}
+
+	clientcredentialsClient := o.clientcredentialsConfig.Client(context.Background())
+
+	o.userCache[username] = userState{
+		username:  username,
+		superuser: false,
+		createdAt: time.Now(),
+		updatedAt: time.Unix(0, 0),
+		client:    clientcredentialsClient,
+		token:     token,
+	}
+
+	return true, err
+}
+
+func (o Oauth2) createUserWithToken(accessToken, clientid string) (bool, error) {
+	token := &go_oauth2.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+	}
+
+	client := o.oauth2Config.Client(context.Background(), token)
+
+	info, err := o.getUserInfo(client)
+
+	if err != nil {
+		log.Println(err)
+		return false, err
+	}
+
+	o.userCache[accessToken] = userState{
+		username:    accessToken,
+		superuser:   info.MQTT.Superuser,
+		createdAt:   time.Now(),
+		updatedAt:   time.Now(),
+		readTopics:  info.MQTT.Topics.Read,
+		writeTopics: info.MQTT.Topics.Write,
+		client:      client,
+		token:       token,
+	}
+
+	return true, err
+}
+
+func (o Oauth2) getUserInfo(client *http.Client) (*UserInfo, error) {
+	req, _ := http.NewRequest("GET", o.userInfoURL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	info := UserInfo{}
+
+	err = json.NewDecoder(resp.Body).Decode(&info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+func (o Oauth2) checkAccessToTopic(topic string, acc int32, cache *userState, username string, clientid string) bool {
+	log.Debugf("Check for acl level %d", acc)
+
+	// check read access
+	if acc == 1 || acc == 4 {
+		res := o.isTopicInList(cache.readTopics, topic, username, clientid)
+		log.Debugf("ACL for read was %t", res)
+		return res
+	}
+
+	// check write
+	if acc == 2 {
+		res := o.isTopicInList(cache.writeTopics, topic, username, clientid)
+		log.Debugf("ACL for write was %t", res)
+		return res
+	}
+
+	// check for readwrite
+	if acc == 3 {
+		res := o.isTopicInList(cache.readTopics, topic, username, clientid) && o.isTopicInList(cache.writeTopics, topic, username, clientid)
+		log.Debugf("ACL for readwrite was %t", res)
+		return res
+	}
+	return false
+}
+
+func (o Oauth2) cacheIsValid(cache *userState) bool {
+	log.Debugf("Cache Expiary: %s", o.cacheDuration)
+	log.Debugf("Last Update: %s", cache.updatedAt)
+	log.Debugf("Difference to now: %s", time.Now().Sub(cache.updatedAt))
+
+	// function tests if the cache of the user is still valid
+	if o.cacheDuration == 0 {
+		return false
+	}
+
+	if (time.Now().Sub(cache.updatedAt)) < o.cacheDuration {
+		return true
+	}
+	return false
+}
+
+func (o Oauth2) isTopicInList(topicList []string, searchedTopic string, username string, clientid string) bool {
+	replacer := strings.NewReplacer("%u", username, "%c", clientid)
+
+	for _, topicFromList := range topicList {
+		if topics.Match(replacer.Replace(topicFromList), searchedTopic) {
+			return true
+		}
+	}
+	return false
+}

--- a/backends/oauth2_test.go
+++ b/backends/oauth2_test.go
@@ -251,7 +251,7 @@ func SuperUserTests(username string, password string, oauth2 *Oauth2, closeServe
 
 	Convey("GetSuperuser() should return false if that user was not registered as superuser by GetUser()", func() {
 		allowed, err := oauth2.GetSuperuser(username)
-		So(err, ShouldBeError)
+		So(err, ShouldBeNil)
 		So(allowed, ShouldBeFalse)
 	})
 	Convey("Given valid superuser username and password GetUser() should return true", func() {

--- a/backends/oauth2_test.go
+++ b/backends/oauth2_test.go
@@ -1,0 +1,303 @@
+package backends
+
+import (
+	log "github.com/sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func setupMockOAuthServer() (*httptest.Server, func()) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+
+		if authHeader == "" || authHeader == "Bearer wrong_token" {
+			http.Error(w, "Fail", 404)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if authHeader == "Bearer mock_access_token_normaluser" {
+			w.Write([]byte("{\"sub\":\"mock_user_id_0\",\"mqtt\":{\"superuser\":false,\"topics\":{\"read\":[\"/test/topic/read/#\",\"/test/topic/writeread/1\",\"/test/topic/pattern/username/%u\",\"/test/topic/pattern/clientid/%c\"],\"write\":[\"/test/topic/write/+/db\",\"/test/topic/writeread/1\"]}}}"))
+		}
+		if authHeader == "Bearer mock_access_token_superuser" {
+			w.Write([]byte("{\"sub\":\"mock_user_id_1\",\"mqtt\":{\"superuser\":true,\"topics\":{\"read\":[\"/test/topic/read/#\",\"/test/topic/writeread/1\"],\"write\":[\"/test/topic/write/+/db\",\"/test/topic/writeread/1\"]}}}"))
+		}
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		// Log Request
+		log.Infof("Server received request: %s", r.URL.String())
+		header := ""
+		for headerKey, headerValueList := range r.Header {
+			header += headerKey + "="
+			for _, value := range headerValueList {
+				header += value + ", "
+			}
+		}
+		log.Infof("Request Headers: %s", header)
+
+		accessToken := r.Form.Get("access_token")
+		// grantType := r.Form.Get("grant_type")
+		username, password, _ := r.BasicAuth()
+
+		// register normal user
+		if (username == "test_normaluser" && password == "test_normaluser") || (username == "test_pattern_user") || accessToken == "mock_access_token_normaluser" {
+			// Should return acccess token back to the user
+			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+			w.Write([]byte("access_token=mock_access_token_normaluser&scope=user&token_type=bearer&refresh_token=mock_refresh_token_normaluser&expires_in=0"))
+			return
+		}
+
+		// register superuser
+		if (username == "test_superuser" && password == "test_superuser") || accessToken == "mock_access_token_normaluser" {
+			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+			w.Write([]byte("access_token=mock_access_token_superuser&scope=user&token_type=bearer&refresh_token=mock_refresh_token_superuser&expires_in=0"))
+			return
+		}
+
+		http.Error(w, "Wrong credentials", 404)
+	})
+
+	server := httptest.NewServer(mux)
+
+	return server, func() {
+		server.Close()
+		log.Infof("Close Testserver")
+	}
+}
+
+func TestOauth2(t *testing.T) {
+
+	authOpts := make(map[string]string)
+	authOpts["oauth_client_id"] = "clientId"
+	authOpts["oauth_client_secret"] = "clientSecret"
+	cacheDuration := 2
+	authOpts["oauth_cache_duration"] = strconv.Itoa(cacheDuration)
+	authOpts["oauth_scopes"] = "all"
+
+	Convey("If mandatory params are not set initialization should fail", t, func() {
+		_, err := NewOauth2(authOpts, log.DebugLevel)
+		So(err, ShouldBeError)
+	})
+
+	Convey("Test authentication and authorization using client credentials", t, func() {
+		server, closeServer := setupMockOAuthServer()
+		authOpts["oauth_token_url"] = server.URL + "/token"
+		authOpts["oauth_userinfo_url"] = server.URL + "/userinfo"
+		log.Infof("Start Testserver on location %s", server.URL)
+
+		Convey("Given valid params NewOauth2() should return a Oauth2 backend instance", func() {
+			oauth2, err := NewOauth2(authOpts, log.ErrorLevel)
+			So(err, ShouldBeNil)
+
+			Convey("Given unvalid username and password GetUser() should return false", func() {
+				allowed, err := oauth2.GetUser("test_wrong_user", "test_wrong_user", "client_id")
+				So(err, ShouldBeError)
+				So(allowed, ShouldBeFalse)
+			})
+
+			// Normal User
+			Convey("Given valid username and password GetUser() should return true", func() {
+				allowed, err := oauth2.GetUser("test_normaluser", "test_normaluser", "client_id")
+				So(err, ShouldBeNil)
+				So(allowed, ShouldBeTrue)
+
+				// Authorization
+				Convey("When requesting read access for a topic included in oauth2-servers /userinfo 'read' response CheckAcl() should be true", func() {
+					// Without username/client_id pattern
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+					// username pattern ("%u")
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/pattern/username/test_normaluser", "clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+					// client_id pattern ("%c")
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/pattern/clientid/test_clientid", "test_clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+				})
+				Convey("When requesting write access for a topic included in oauth2-servers/userinfo 'write' response CheckAcl() should be true", func() {
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/write/influx/db", "client_id", 2)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+
+				})
+				Convey("When requesting readwrite access for a topic included in oauth2-servers /userinfo 'read' and 'write' response CheckAcl() should be true", func() {
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/writeread/1", "client_id", 3)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+				})
+				Convey("When requesting read access for a topic included in oauth2-servers /userinfo 'read' response CheckAcl() should be false", func() {
+					// Without username/client_id pattern
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/wrong_topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+					// username pattern ("%u")
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/pattern/username/test_wrong_user", "clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+					// client_id pattern ("%c")
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/topic/pattern/clientid/test_wrong_clientid", "test_clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+				})
+				Convey("When requesting write access for a topic included in oauth2-servers/userinfo 'write' response CheckAcl() should be false", func() {
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/wrong_topic/write/influx/db", "client_id", 2)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+				})
+				Convey("When requesting readwrite access for a topic included in oauth2-servers /userinfo 'read' and 'write' response CheckAcl() should be false", func() {
+					allowed, err = oauth2.CheckAcl("test_normaluser", "/test/wrong_topic/writeread/1", "client_id", 3)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+				})
+			})
+
+			// Super User
+			Convey("GetSuperuser() should return false if that user was not registered as superuser by GetUser()", func() {
+				allowed, err := oauth2.GetSuperuser("test_normaluser")
+				So(err, ShouldBeError)
+				So(allowed, ShouldBeFalse)
+			})
+			Convey("Given valid superuser username and password GetUser() should return true", func() {
+				allowed, err := oauth2.GetUser("test_superuser", "test_superuser", "client_id")
+				So(err, ShouldBeNil)
+				So(allowed, ShouldBeTrue)
+				Convey("For a given superuser `username` GetSuperuser() should return true if that superuser was registered as superuser by GetUser()", func() {
+					allowed, err := oauth2.GetSuperuser("test_superuser")
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+				})
+				// Test cache expiry and token refreshment
+				Convey("Refresh Tokens should be updated succesfully after cache expiry", func() {
+					allowed, err = oauth2.CheckAcl("test_superuser", "/test/topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+					allowed, err = oauth2.GetSuperuser("test_superuser")
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+
+					time.Sleep(time.Duration(cacheDuration+1) * time.Second)
+
+					allowed, err = oauth2.CheckAcl("test_superuser", "/test/topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+					allowed, err = oauth2.GetSuperuser("test_superuser")
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+
+					closeServer()
+					time.Sleep(time.Duration(cacheDuration+1) * time.Second)
+
+					allowed, err = oauth2.CheckAcl("test_superuser", "/test/topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeError)
+					So(allowed, ShouldBeFalse)
+					allowed, err = oauth2.GetSuperuser("test_superuser")
+					So(err, ShouldBeError)
+					So(allowed, ShouldBeFalse)
+				})
+			})
+		})
+	})
+
+	Convey("Test authentication and authorization using access token", t, func() {
+		server, closeServer := setupMockOAuthServer()
+		defer closeServer()
+		authOpts["oauth_token_url"] = server.URL + "/token"
+		authOpts["oauth_userinfo_url"] = server.URL + "/userinfo"
+		log.Infof("Start Testserver on location %s", server.URL)
+
+		Convey("Given valid params NewOauth2() should return a Oauth2 backend instance", func() {
+			oauth2, err := NewOauth2(authOpts, log.DebugLevel)
+			So(err, ShouldBeNil)
+
+			Convey("Given an unvalid access token GetUser() should return false", func() {
+				allowed, err := oauth2.GetUser("wrong_access_token", "oauthbearer_empty_password", "client_id")
+				So(err, ShouldBeError)
+				So(allowed, ShouldBeFalse)
+			})
+
+			// Normal User
+			Convey("Given a valid access token GetUser() should return true", func() {
+				allowed, err := oauth2.GetUser("mock_access_token_normaluser", "oauthbearer_empty_password", "client_id")
+				So(err, ShouldBeNil)
+				So(allowed, ShouldBeTrue)
+
+				// Authorization
+				Convey("When requesting read access for a topic included in oauth2-servers /userinfo 'read' response CheckAcl() should be true", func() {
+					// Without username/client_id pattern
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+					// username pattern ("%u")
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/pattern/username/mock_access_token_normaluser", "clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+					// client_id pattern ("%c")
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/pattern/clientid/test_clientid", "test_clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+				})
+				Convey("When requesting write access for a topic included in oauth2-servers/userinfo 'write' response CheckAcl() should be true", func() {
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/write/influx/db", "client_id", 2)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+
+				})
+				Convey("When requesting readwrite access for a topic included in oauth2-servers /userinfo 'read' and 'write' response CheckAcl() should be true", func() {
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/writeread/1", "client_id", 3)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+				})
+				Convey("When requesting read access for a topic included in oauth2-servers /userinfo 'read' response CheckAcl() should be false", func() {
+					// Without username/client_id pattern
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/wrong_topic/read/sensor", "client_id", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+					// username pattern ("%u")
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/pattern/username/test_wrong_user", "clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+					// client_id pattern ("%c")
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/topic/pattern/clientid/test_wrong_clientid", "test_clientid", 1)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+				})
+				Convey("When requesting write access for a topic included in oauth2-servers/userinfo 'write' response CheckAcl() should be false", func() {
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/wrong_topic/write/influx/db", "client_id", 2)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+				})
+				Convey("When requesting readwrite access for a topic included in oauth2-servers /userinfo 'read' and 'write' response CheckAcl() should be false", func() {
+					allowed, err = oauth2.CheckAcl("mock_access_token_normaluser", "/test/wrong_topic/writeread/1", "client_id", 3)
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeFalse)
+				})
+			})
+
+			// Super User
+			Convey("GetSuperuser() should return false if that user was not registered as superuser by GetUser()", func() {
+				allowed, err := oauth2.GetSuperuser("mock_access_token_normaluser")
+				So(err, ShouldBeError)
+				So(allowed, ShouldBeFalse)
+			})
+			Convey("Given valid superuser access token GetUser() should return true", func() {
+				allowed, err := oauth2.GetUser("mock_access_token_superuser", "oauthbearer_empty_password", "client_id")
+				So(err, ShouldBeNil)
+				So(allowed, ShouldBeTrue)
+				Convey("For a given superuser GetSuperuser() should return true if that superuser was registered as superuser by GetUser()", func() {
+					allowed, err := oauth2.GetSuperuser("mock_access_token_superuser")
+					So(err, ShouldBeNil)
+					So(allowed, ShouldBeTrue)
+				})
+			})
+		})
+	})
+
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.mongodb.org/mongo-driver v1.5.1
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 // indirect
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be // indirect
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
 	google.golang.org/genproto v0.0.0-20200521103424-e9a78aa275b7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,7 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -265,6 +266,7 @@ golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
### Summary
The branch contains a new backend enabling authentication and authorization using an oauth2/openid-connect server.


Clients can either
 - hand over client credentials, i.e.  `client_id` and a `client_secret` ([client_credentials-oauth2-specification](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)) or 
 - pass an `access_token` ([access_token-oauth2-specification](https://datatracker.ietf.org/doc/html/rfc6749#section-1.4))

**Note**
The code is based on [this](https://github.com/gewv-tu-dresden/mosquitto-go-auth-oauth2) project which implements the mosquitto-go-auth plugin backend.

### Access Token Authentication
If the backend receives the password `oauthbearer_empty_password` it assumes the username to be an `access_token`. Mosquitto seems to not allow empty passwords. If this can be changed the placeholder password could be removed. When using this option the the client has to reconnect using a new `access_token` after the old `access_token` has expired.

### Client Credentials Authentication
Any other combination of `username` and `password` is assumed to be a `client_id`/`client_secret`-pair and is used to obtain an `access_token`s from the authorization server regularly. Therefore client do not have to reconnect after token expiry in this case.

### Requesting Topic Permissions
In both cases the available `access_token` is used to request the servers `/userinfo`-endpoint ([userinfo-openid-specificaton](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)). The backend expects the response of this request to look like
```
{
    "sub": "<username>",
    "mqtt": {
        "topics": {
            "read": ["/test/#", "/test/read/#],
            "write": ["/test/#","/test/write/#]
        },
        "superuser": false
    }
}
```
which contains the allowed topics for reading and writing corresponding to the provided `access_token`.

### Tests
Tests are implemented by using a mock oauth2 server.
