### PR TITLE
HTTP/JWT request method

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,8 +892,9 @@ The following `auth_opt_` options are supported by the `jwt` backend when remote
 | jwt_response_mode | status    |     N     | Response type (status, json, text) |
 | jwt_params_mode   | json      |     N     | Data type (json, form)             |
 | jwt_user_agent    | mosquitto |     N     | User agent for requests            |
+| jwt_http_method   | POST      |     N     | Http method used (POST, GET, PUT)  |
 
-URIs (like jwt_getuser_uri) are expected to be in the form `/path`. For example, if jwt_with_tls is `false`, jwt_host is `localhost`, jwt_port `3000` and jwt_getuser_uri is `/user`, mosquitto will send a POST request to `http://localhost:3000/user` to get a response to check against. How data is sent (either json encoded or as form values) and received (as a simple http status code, a json encoded response or plain text), is given by options jwt_response_mode and jwt_params_mode.
+URIs (like jwt_getuser_uri) are expected to be in the form `/path`. For example, if jwt_with_tls is `false`, jwt_host is `localhost`, jwt_port `3000` and jwt_getuser_uri is `/user`, mosquitto will send a http request to `http://localhost:3000/user` to get a response to check against. How data is sent (either json encoded or as form values) and received (as a simple http status code, a json encoded response or plain text), is given by options jwt_response_mode and jwt_params_mode.
 
 If the option `jwt_superuser_uri` is not set then `superuser` checks are disabled for this mode.
 
@@ -1144,6 +1145,7 @@ The following `auth_opt_` options are supported:
 | http_params_mode   | json      |     N     | Data type (json, form)             |
 | http_timeout       | 5         |     N     | Timeout in seconds                 |
 | http_user_agent    | mosquitto |     N     | User Agent to use in requests      |
+| http_method        | POST      |     N     | Http method used (POST, GET, PUT)  |
 
 #### Response mode
 

--- a/backends/http.go
+++ b/backends/http.go
@@ -46,7 +46,7 @@ func NewHTTP(authOpts map[string]string, logLevel log.Level, version string) (HT
 		VerifyPeer:   false,
 		ResponseMode: "status",
 		ParamsMode:   "json",
-		httpMethod:   "POST",
+		httpMethod:   h.MethodPost,
 	}
 
 	missingOpts := ""
@@ -65,7 +65,8 @@ func NewHTTP(authOpts map[string]string, logLevel log.Level, version string) (HT
 	}
 
 	if httpMethod, ok := authOpts["http_method"]; ok {
-		if httpMethod == "POST" || httpMethod == "GET" || httpMethod == "PUT" {
+		switch httpMethod {
+		case h.MethodGet, h.MethodPut:
 			http.httpMethod = httpMethod
 		}
 	}
@@ -218,10 +219,9 @@ func (o HTTP) httpRequest(uri, username string, dataMap map[string]interface{}, 
 	var err error
 
 	if o.ParamsMode == "form" {
-		if o.httpMethod != "POST" {
-			log.Errorf("error form param only supported for POST.")
-			err = fmt.Errorf("form only supported for POST, error code: %d",
-				500)
+		if o.httpMethod != h.MethodPost && o.httpMethod != h.MethodPut {
+			log.Errorf("error form param only supported for POST/PUT.")
+			err = fmt.Errorf("form only supported for POST/PUT, error code: %d", 500)
 			return false, err
 		}
 

--- a/backends/http_test.go
+++ b/backends/http_test.go
@@ -103,6 +103,7 @@ func TestHTTPAllJsonServer(t *testing.T) {
 		hb, err := NewHTTP(authOpts, log.DebugLevel, version)
 		So(err, ShouldBeNil)
 		So(hb.UserAgent, ShouldEqual, "mosquitto-2.0.0")
+		So(hb.httpMethod, ShouldEqual, http.MethodPost)
 
 		Convey("Given custom user agent, it should override default one", func() {
 			customAuthOpts := make(map[string]string)
@@ -116,6 +117,34 @@ func TestHTTPAllJsonServer(t *testing.T) {
 			customHb, err := NewHTTP(customAuthOpts, log.DebugLevel, version)
 			So(err, ShouldBeNil)
 			So(customHb.UserAgent, ShouldEqual, "custom-user-agent")
+		})
+
+		Convey("Given http method GET, it should override the default POST one", func() {
+			customAuthOpts := make(map[string]string)
+
+			for k, v := range authOpts {
+				customAuthOpts[k] = v
+			}
+
+			customAuthOpts["http_method"] = "GET"
+
+			customHb, err := NewHTTP(customAuthOpts, log.DebugLevel, version)
+			So(err, ShouldBeNil)
+			So(customHb.httpMethod, ShouldEqual, http.MethodGet)
+		})
+
+		Convey("Given http method PUT, it should override the default POST one", func() {
+			customAuthOpts := make(map[string]string)
+
+			for k, v := range authOpts {
+				customAuthOpts[k] = v
+			}
+
+			customAuthOpts["http_method"] = "PUT"
+
+			customHb, err := NewHTTP(customAuthOpts, log.DebugLevel, version)
+			So(err, ShouldBeNil)
+			So(customHb.httpMethod, ShouldEqual, http.MethodPut)
 		})
 
 		Convey("Given correct password/username, get user should return true", func() {

--- a/backends/jwt_remote.go
+++ b/backends/jwt_remote.go
@@ -27,6 +27,7 @@ type remoteJWTChecker struct {
 	verifyPeer   bool
 
 	paramsMode   string
+	httpMethod   string
 	responseMode string
 
 	options tokenOptions
@@ -45,6 +46,7 @@ func NewRemoteJWTChecker(authOpts map[string]string, options tokenOptions, versi
 		verifyPeer:   false,
 		responseMode: "status",
 		paramsMode:   "json",
+		httpMethod:   "POST",
 		options:      options,
 	}
 
@@ -60,6 +62,12 @@ func NewRemoteJWTChecker(authOpts map[string]string, options tokenOptions, versi
 	if paramsMode, ok := authOpts["jwt_params_mode"]; ok {
 		if paramsMode == "form" {
 			checker.paramsMode = paramsMode
+		}
+	}
+
+	if httpMethod, ok := authOpts["jwt_http_method"]; ok {
+		if httpMethod == "POST" || httpMethod == "GET" || httpMethod == "PUT" {
+			checker.httpMethod = httpMethod
 		}
 	}
 
@@ -239,7 +247,7 @@ func (o *remoteJWTChecker) jwtRequest(host, uri, token string, dataMap map[strin
 		}
 
 		contentReader := bytes.NewReader(dataJSON)
-		req, err = h.NewRequest("POST", fullURI, contentReader)
+		req, err = h.NewRequest(o.httpMethod, fullURI, contentReader)
 
 		if err != nil {
 			log.Errorf("req error: %s", err)
@@ -248,7 +256,7 @@ func (o *remoteJWTChecker) jwtRequest(host, uri, token string, dataMap map[strin
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", o.userAgent)
 	default:
-		req, err = h.NewRequest("POST", fullURI, strings.NewReader(urlValues.Encode()))
+		req, err = h.NewRequest(o.httpMethod, fullURI, strings.NewReader(urlValues.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Content-Length", strconv.Itoa(len(urlValues.Encode())))
 		req.Header.Set("User-Agent", o.userAgent)

--- a/backends/jwt_remote.go
+++ b/backends/jwt_remote.go
@@ -46,7 +46,7 @@ func NewRemoteJWTChecker(authOpts map[string]string, options tokenOptions, versi
 		verifyPeer:   false,
 		responseMode: "status",
 		paramsMode:   "json",
-		httpMethod:   "POST",
+		httpMethod:   h.MethodPost,
 		options:      options,
 	}
 
@@ -66,7 +66,8 @@ func NewRemoteJWTChecker(authOpts map[string]string, options tokenOptions, versi
 	}
 
 	if httpMethod, ok := authOpts["jwt_http_method"]; ok {
-		if httpMethod == "POST" || httpMethod == "GET" || httpMethod == "PUT" {
+		switch httpMethod {
+		case h.MethodGet, h.MethodPut:
 			checker.httpMethod = httpMethod
 		}
 	}


### PR DESCRIPTION
Adds support for GET/PUT request methods while defaulting to POST for HTTP/JWT backends.

It's based on and closes https://github.com/iegomez/mosquitto-go-auth/pull/221, it just uses http package constants and adds a couple of tests.