### PR TITLE
Dockerfile upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,13 +105,9 @@ COPY --from=mosquitto_builder /usr/local/bin/mosquitto_sub /usr/bin/mosquitto_su
 COPY --from=mosquitto_builder /usr/local/bin/mosquitto_pub /usr/bin/mosquitto_pub
 COPY --from=mosquitto_builder /usr/local/bin/mosquitto_rr /usr/bin/mosquitto_rr
 
-EXPOSE 1883 1884
-
-#RUN set -ex; echo "mosquitto_sub -t '\$SYS/#' -C 1 -p 1883 | grep -v Error || exit 1" > /healthcheck.sh
 RUN set -ex; ldconfig;
 
-#HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-#    CMD ["/bin/sh", "-c", "/healthcheck.sh"]
+EXPOSE 1883 1884
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD [ "/usr/sbin/mosquitto" ,"-c", "/etc/mosquitto/mosquitto.conf" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 # Define Mosquitto version
-ARG MOSQUITTO_VERSION=1.6.14
+ARG MOSQUITTO_VERSION=2.0.9
+# Define libwebsocket version
+ARG LWS_VERSION=2.4.2
 
 # Use debian:stable-slim as a builder for Mosquitto and dependencies.
 FROM debian:stable-slim as mosquitto_builder
 ARG MOSQUITTO_VERSION
+ARG LWS_VERSION
 
 # Get mosquitto build dependencies.
-RUN apt update && apt install -y wget build-essential cmake libssl-dev  libcjson-dev
+RUN set -ex; apt-get update; apt-get install -y wget build-essential cmake libssl-dev libcjson-dev
 
 # Get libwebsocket. Debian's libwebsockets is too old for Mosquitto version > 2.x so it gets built from source.
-RUN export LWS_VERSION=2.4.2  && \
-    wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
-    mkdir -p /build/lws && \
-    tar --strip=1 -xf /tmp/lws.tar.gz -C /build/lws && \
-    rm /tmp/lws.tar.gz && \
-    cd /build/lws && \
+RUN set -ex; \
+    wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz; \
+    mkdir -p /build/lws; \
+    tar --strip=1 -xf /tmp/lws.tar.gz -C /build/lws; \
+    rm /tmp/lws.tar.gz; \
+    cd /build/lws; \
     cmake . \
         -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DCMAKE_INSTALL_PREFIX=/usr \
@@ -26,23 +29,19 @@ RUN export LWS_VERSION=2.4.2  && \
         -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
-        -DLWS_WITH_ZLIB=OFF && \
-    make -j "$(nproc)" && \
+        -DLWS_WITH_ZLIB=OFF; \
+    make -j "$(nproc)"; \
     rm -rf /root/.cmake
 
 WORKDIR /app
 
-RUN mkdir -p mosquitto/auth mosquitto/conf.d
+RUN set -ex; mkdir -p mosquitto/auth mosquitto/conf.d
 
-RUN wget http://mosquitto.org/files/source/mosquitto-${MOSQUITTO_VERSION}.tar.gz
-RUN tar xzvf mosquitto-${MOSQUITTO_VERSION}.tar.gz
+RUN set -ex; wget http://mosquitto.org/files/source/mosquitto-${MOSQUITTO_VERSION}.tar.gz
+RUN set -ex; tar xzvf mosquitto-${MOSQUITTO_VERSION}.tar.gz
 
 # Build mosquitto.
-RUN if [ "$(echo $MOSQUITTO_VERSION | head -c 1)" != 2 ]; then \
-   cd mosquitto-${MOSQUITTO_VERSION} && make CFLAGS="-Wall -O2 -I/build/lws/include" LDFLAGS="-L/build/lws/lib" WITH_WEBSOCKETS=yes && make install ; \
-   else \
-   cd mosquitto-${MOSQUITTO_VERSION} && make CFLAGS="-Wall -O2 -I/build/lws/include" LDFLAGS="-L/build/lws/lib" WITH_WEBSOCKETS=yes && make install ; \
-   fi
+RUN set -ex; cd mosquitto-${MOSQUITTO_VERSION}; make CFLAGS="-Wall -O2 -I/build/lws/include" LDFLAGS="-L/build/lws/lib" WITH_WEBSOCKETS=yes; make install;
 
 # Use golang:latest as a builder for the Mosquitto Go Auth plugin.
 FROM --platform=$BUILDPLATFORM golang:latest AS go_auth_builder
@@ -60,7 +59,7 @@ COPY --from=tonistiigi/xx:golang / /
 RUN go env
 
 # Install needed libc and gcc for target platform.
-RUN if [ ! -z "$TARGETPLATFORM" ]; then \
+RUN set -ex; if [ ! -z "$TARGETPLATFORM" ]; then \
     case "$TARGETPLATFORM" in \
   "linux/arm64") \
     apt update && apt install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
@@ -78,37 +77,14 @@ WORKDIR /app
 COPY --from=mosquitto_builder /usr/local/include/ /usr/local/include/
 
 COPY ./ ./
-RUN go build -buildmode=c-archive go-auth.go && \
-    go build -buildmode=c-shared -o go-auth.so && \
-	go build pw-gen/pw.go
-
+RUN set -ex; go build -buildmode=c-archive go-auth.go; \
+    go build -buildmode=c-shared -o go-auth.so; \
+	  go build pw-gen/pw.go
 
 #Start from a new image.
 FROM debian:stable-slim
 
-RUN apt update && apt install -y libc-ares2 openssl uuid tini wget cmake libssl-dev
-
-# Get libwebsocket. Debian's libwebsockets is too old for Mosquitto version > 2.x so it gets built from source.
-RUN export LWS_VERSION=2.4.2  && \
-    wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
-    mkdir -p /build/lws && \
-    tar --strip=1 -xf /tmp/lws.tar.gz -C /build/lws && \
-    rm /tmp/lws.tar.gz && \
-    cd /build/lws && \
-    cmake . \
-        -DCMAKE_BUILD_TYPE=MinSizeRel \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DLWS_IPV6=ON \
-        -DLWS_WITHOUT_BUILTIN_GETIFADDRS=ON \
-        -DLWS_WITHOUT_CLIENT=ON \
-        -DLWS_WITHOUT_EXTENSIONS=ON \
-        -DLWS_WITHOUT_TESTAPPS=ON \
-        -DLWS_WITH_HTTP2=OFF \
-        -DLWS_WITH_SHARED=OFF \
-        -DLWS_WITH_ZIP_FOPS=OFF \
-        -DLWS_WITH_ZLIB=OFF && \
-    make -j "$(nproc)" && \
-    rm -rf /root/.cmake
+RUN set -ex; apt update; apt install -y libc-ares2 openssl uuid tini wget libssl-dev libcjson-dev
 
 RUN mkdir -p /var/lib/mosquitto /var/log/mosquitto
 RUN groupadd mosquitto \
@@ -122,7 +98,20 @@ COPY --from=go_auth_builder /app/pw /mosquitto/pw
 COPY --from=go_auth_builder /app/go-auth.so /mosquitto/go-auth.so
 COPY --from=mosquitto_builder /usr/local/sbin/mosquitto /usr/sbin/mosquitto
 
+COPY --from=mosquitto_builder /usr/local/lib/libmosquitto* /usr/local/lib/
+
+COPY --from=mosquitto_builder /usr/local/bin/mosquitto_passwd /usr/bin/mosquitto_passwd
+COPY --from=mosquitto_builder /usr/local/bin/mosquitto_sub /usr/bin/mosquitto_sub
+COPY --from=mosquitto_builder /usr/local/bin/mosquitto_pub /usr/bin/mosquitto_pub
+COPY --from=mosquitto_builder /usr/local/bin/mosquitto_rr /usr/bin/mosquitto_rr
+
 EXPOSE 1883 1884
+
+#RUN set -ex; echo "mosquitto_sub -t '\$SYS/#' -C 1 -p 1883 | grep -v Error || exit 1" > /healthcheck.sh
+RUN set -ex; ldconfig;
+
+#HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+#    CMD ["/bin/sh", "-c", "/healthcheck.sh"]
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD [ "/usr/sbin/mosquitto" ,"-c", "/etc/mosquitto/mosquitto.conf" ]


### PR DESCRIPTION
Hi!

I've refactored the Dockerfile removing duplicate entries.
`libwebsocket` was compiled twice in two images but the second time was not required because the library is linked statically in the binary. (or at least it seems so, everything is working so...)
Also the final image now contains `mosquitto_*` utils and the required libraries (`libmosquitto.so` and `libmosquittopp.so`) enabling health checking of the container and some more scripting/automation during deployments. 