### PR TITLE
feat: makes mutual TLS optional for postgres, mysql/mariadb and grpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ vendor
 .idea/
 .vscode/
 
+# generated test certificates, keys and CSRs
+test-files/certificates/**/*.csr
+test-files/certificates/**/*.pem
 
 # todo
 TODO

--- a/Dockerfile.runtest
+++ b/Dockerfile.runtest
@@ -6,7 +6,7 @@ FROM debian:stable-slim as builder
 #Change them for your needs.
 ENV MOSQUITTO_VERSION=1.6.10
 ENV PLUGIN_VERSION=0.6.1
-ENV GO_VERSION=1.13.8
+ENV GO_VERSION=1.18
 
 WORKDIR /app
 

--- a/Dockerfile.runtest
+++ b/Dockerfile.runtest
@@ -7,6 +7,9 @@ FROM debian:stable-slim as builder
 ENV MOSQUITTO_VERSION=1.6.10
 ENV PLUGIN_VERSION=0.6.1
 ENV GO_VERSION=1.18
+# Used in run-test-in-docker.sh to check if the script
+# is actually run in a container
+ENV MOSQUITTO_GO_AUTH_TEST_RUNNING_IN_A_CONTAINER=true
 
 WORKDIR /app
 
@@ -67,6 +70,10 @@ RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
     ln -s /bin/true /usr/bin/systemctl && \
     apt-get install -y mongodb-org && \
     rm -f /usr/bin/systemctl
+
+# Install CFSSL to generate test certificates required for tests
+RUN export PATH=$PATH:/usr/local/go/bin && go install github.com/cloudflare/cfssl/cmd/cfssl@v1.6.2 && cp ~/go/bin/cfssl /usr/local/bin
+RUN export PATH=$PATH:/usr/local/go/bin && go install github.com/cloudflare/cfssl/cmd/cfssljson@v1.6.2 && cp ~/go/bin/cfssljson /usr/local/bin
 
 # Pre-compilation of test for speed-up latest re-run
 RUN export PATH=$PATH:/usr/local/go/bin && go test -c ./backends -o /dev/null

--- a/README.md
+++ b/README.md
@@ -1409,8 +1409,8 @@ The following `auth_opt_` options are supported:
 | grpc_host                 |                   |      Y      | gRPC server hostname   		   |
 | grpc_port                 |                   |      Y      | gRPC server port number        |
 | grpc_ca_cert   	        |                   |      N      | gRPC server CA cert path	   |
-| grpc_tls_cert 	        |                   |      N      | gRPC server TLS cert path      |
-| grpc_tls_key  	        |                   |      N      | gRPC server TLS key path       |
+| grpc_tls_cert 	        |                   |      N      | gRPC client TLS cert path      |
+| grpc_tls_key  	        |                   |      N      | gRPC client TLS key path       |
 | grpc_disable_superuser    |       false       |      N      | disable superuser checks       |
 | grpc_fail_on_dial_error   |       false       |      N      | fail to init on dial error     |
 | grpc_dial_timeout_ms      |       500         |      N      | dial timeout in ms             |

--- a/backends/grpc.go
+++ b/backends/grpc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"google.golang.org/grpc/credentials/insecure"
 	"strconv"
 	"time"
 
@@ -173,7 +174,7 @@ func setup(hostname string, caCert, tlsCert, tlsKey []byte, withBlock bool) ([]g
 	}
 
 	if len(caCert) == 0 {
-		nsOpts = append(nsOpts, grpc.WithInsecure())
+		nsOpts = append(nsOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		log.WithField("server", hostname).Warning("creating insecure grpc client")
 	} else {
 		log.WithField("server", hostname).Info("creating grpc client")

--- a/backends/grpc_test.go
+++ b/backends/grpc_test.go
@@ -2,14 +2,17 @@ package backends
 
 import (
 	"context"
-	"net"
-	"testing"
-
+	"crypto/tls"
+	"crypto/x509"
 	"github.com/golang/protobuf/ptypes/empty"
 	gs "github.com/iegomez/mosquitto-go-auth/grpc"
 	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"io/ioutil"
+	"net"
+	"testing"
 )
 
 const (
@@ -183,4 +186,123 @@ func TestGRPC(t *testing.T) {
 		})
 	})
 
+}
+
+func TestGRPCTls(t *testing.T) {
+	Convey("Given a mock grpc server with TLS", t, func(c C) {
+		serverCert, err := tls.LoadX509KeyPair("/test-files/certificates/grpc/fullchain-server.pem",
+			"/test-files/certificates/grpc/server-key.pem")
+		c.So(err, ShouldBeNil)
+
+		config := &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			ClientAuth:   tls.NoClientCert,
+		}
+		grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(config)))
+		gs.RegisterAuthServiceServer(grpcServer, NewAuthServiceAPI())
+
+		listen, err := net.Listen("tcp", ":3123")
+		c.So(err, ShouldBeNil)
+
+		go grpcServer.Serve(listen)
+		defer grpcServer.Stop()
+
+		authOpts := make(map[string]string)
+		authOpts["grpc_host"] = "localhost"
+		authOpts["grpc_port"] = "3123"
+		authOpts["grpc_dial_timeout_ms"] = "100"
+		authOpts["grpc_fail_on_dial_error"] = "true"
+
+		Convey("Given client connects without TLS, it should fail", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeError)
+			c.So(err.Error(), ShouldEqual, "context deadline exceeded")
+			c.So(g, ShouldBeNil)
+		})
+
+		authOpts["grpc_ca_cert"] = "/test-files/certificates/db/ca.pem"
+
+		Convey("Given client connects with TLS but with wrong CA, it should fail", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeError)
+			c.So(err.Error(), ShouldEqual, "context deadline exceeded")
+			c.So(g, ShouldBeNil)
+		})
+
+		authOpts["grpc_ca_cert"] = "/test-files/certificates/ca.pem"
+
+		Convey("Given client connects with TLS, it should work", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeNil)
+			c.So(g, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestGRPCMutualTls(t *testing.T) {
+	Convey("Given a mock grpc server with TLS", t, func(c C) {
+		serverCert, err := tls.LoadX509KeyPair("/test-files/certificates/grpc/fullchain-server.pem",
+			"/test-files/certificates/grpc/server-key.pem")
+		c.So(err, ShouldBeNil)
+
+		clientCaBytes, err := ioutil.ReadFile("/test-files/certificates/grpc/ca.pem")
+		c.So(err, ShouldBeNil)
+		clientCaCertPool := x509.NewCertPool()
+		c.So(clientCaCertPool.AppendCertsFromPEM(clientCaBytes), ShouldBeTrue)
+
+		config := &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientCAs:    clientCaCertPool,
+		}
+		grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(config)))
+		gs.RegisterAuthServiceServer(grpcServer, NewAuthServiceAPI())
+
+		listen, err := net.Listen("tcp", ":3123")
+		c.So(err, ShouldBeNil)
+
+		go grpcServer.Serve(listen)
+		defer grpcServer.Stop()
+
+		authOpts := make(map[string]string)
+		authOpts["grpc_host"] = "localhost"
+		authOpts["grpc_port"] = "3123"
+		authOpts["grpc_dial_timeout_ms"] = "100"
+		authOpts["grpc_fail_on_dial_error"] = "true"
+
+		Convey("Given client connects without TLS, it should fail", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeError)
+			c.So(err.Error(), ShouldEqual, "context deadline exceeded")
+			c.So(g, ShouldBeNil)
+		})
+
+		authOpts["grpc_ca_cert"] = "/test-files/certificates/ca.pem"
+
+		Convey("Given client connects with TLS but without a client certificate, it should fail", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeError)
+			c.So(err.Error(), ShouldEqual, "context deadline exceeded")
+			c.So(g, ShouldBeNil)
+		})
+
+		authOpts["grpc_tls_cert"] = "/test-files/certificates/db/client.pem"
+		authOpts["grpc_tls_key"] = "/test-files/certificates/db/client-key.pem"
+
+		Convey("Given client connects with mTLS but with client cert from wrong CA, it should fail", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeError)
+			c.So(err.Error(), ShouldEqual, "context deadline exceeded")
+			c.So(g, ShouldBeNil)
+		})
+
+		authOpts["grpc_tls_cert"] = "/test-files/certificates/grpc/client.pem"
+		authOpts["grpc_tls_key"] = "/test-files/certificates/grpc/client-key.pem"
+
+		Convey("Given client connects with mTLS, it should work", func() {
+			g, err := NewGRPC(authOpts, log.DebugLevel)
+			c.So(err, ShouldBeNil)
+			c.So(g, ShouldNotBeNil)
+		})
+	})
 }

--- a/backends/postgres.go
+++ b/backends/postgres.go
@@ -99,10 +99,7 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 
 	if sslmode, ok := authOpts["pg_sslmode"]; ok {
 		switch sslmode {
-		case "verify-full":
-		case "verify-ca":
-		case "require":
-		case "disable":
+		case "verify-full", "verify-ca", "require", "disable":
 		default:
 			log.Warnf("PG backend warning: using unknown pg_sslmode: '%s'", sslmode)
 		}

--- a/backends/postgres.go
+++ b/backends/postgres.go
@@ -51,7 +51,6 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 		SuperuserQuery: "",
 		AclQuery:       "",
 		hasher:         hasher,
-		connectTries:   -1,
 	}
 
 	if host, ok := authOpts["pg_host"]; ok {

--- a/backends/postgres.go
+++ b/backends/postgres.go
@@ -98,11 +98,12 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 		postgres.AclQuery = aclQuery
 	}
 
-	checkSSL := true
+	checkSSL := false
 	useSslClientCertificate := false
 
 	if sslmode, ok := authOpts["pg_sslmode"]; ok {
 		postgres.SSLMode = sslmode
+		checkSSL = true
 	} else {
 		postgres.SSLMode = "disable"
 	}
@@ -142,7 +143,7 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 		connStr = fmt.Sprintf("%s sslmode=disable", connStr)
 	}
 
-	if useSslClientCertificate {
+	if checkSSL && useSslClientCertificate {
 		if postgres.SSLCert != "" && postgres.SSLKey != "" {
 			connStr = fmt.Sprintf("%s sslcert=%s sslkey=%s", connStr, postgres.SSLCert, postgres.SSLKey)
 		} else {

--- a/backends/postgres.go
+++ b/backends/postgres.go
@@ -98,6 +98,14 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 	}
 
 	if sslmode, ok := authOpts["pg_sslmode"]; ok {
+		switch sslmode {
+		case "verify-full":
+		case "verify-ca":
+		case "require":
+		case "disable":
+		default:
+			log.Warnf("PG backend warning: using unknown pg_sslmode: '%s'", sslmode)
+		}
 		postgres.SSLMode = sslmode
 	} else {
 		postgres.SSLMode = "disable"
@@ -126,13 +134,10 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 	switch postgres.SSLMode {
 	case "require":
 		connStr = fmt.Sprintf("%s sslmode=require", connStr)
-
 	case "verify-ca":
 		connStr = fmt.Sprintf("%s sslmode=verify-ca", connStr)
-
 	case "verify-full":
 		connStr = fmt.Sprintf("%s sslmode=verify-full", connStr)
-
 	case "disable":
 		fallthrough
 	default:

--- a/run-test-in-docker.sh
+++ b/run-test-in-docker.sh
@@ -1,17 +1,127 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script is make to be run in Docker image build by Dockerfile.test
 
-service postgresql start
-service mariadb start
-service redis-server start
+function checkIfContainer {
+  if [[ $MOSQUITTO_GO_AUTH_TEST_RUNNING_IN_A_CONTAINER != "true" ]]; then
+    echo "This script is only supposed run in a container as it modifies the system and databases."
+    exit 1
+  fi
+}
 
-sudo -u mongodb mongod --config /etc/mongod.conf &
+function prepareAndStartPostgres {
+  local POSTGRES_MAJOR_VERSION=$(sudo find /usr/lib/postgresql -wholename '/usr/lib/postgresql/*/bin/postgres' | grep -Eo '[0-9]+')
+  local POSTGRES_POSTGRESQL_CONF_FILE="/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/postgresql.conf"
+  local POSTGRES_PG_HBA_FILE="/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/pg_hba.conf"
 
-mkdir /tmp/cluster-test
-cd /tmp/cluster-test
-mkdir 7000 7001 7002 7003 7004 7005
-cat > 7000/redis.conf << EOF
+  # Postgres requires 'postgres' to be owner of the server key
+  mkdir -p /etc/ssl/private/postgresql
+  cp -r /test-files/certificates/db/server-key.pem /etc/ssl/private/postgresql/server-key.pem
+  chown postgres:postgres -R /etc/ssl/private/postgresql
+  usermod -aG ssl-cert postgres
+
+  sed -i "/^ssl_(ca|cert|key)_file)/d" $POSTGRES_POSTGRESQL_CONF_FILE
+  cat >> $POSTGRES_POSTGRESQL_CONF_FILE <<- EOF
+ssl_ca_file = '/test-files/certificates/db/fullchain-server.pem'
+ssl_cert_file = '/test-files/certificates/db/server.pem'
+ssl_key_file = '/etc/ssl/private/postgresql/server-key.pem'
+EOF
+
+  local PG_HBA_TLS_ENTRIES=$(cat <<- EOF
+hostssl  all  go_auth_test_tls  0.0.0.0/0  md5
+hostnossl  all  go_auth_test_tls  0.0.0.0/0  reject
+hostssl  all  go_auth_test_mutual_tls  0.0.0.0/0  md5 clientcert=verify-ca
+hostnossl  all  go_auth_test_mutual_tls  0.0.0.0/0  reject
+EOF)
+  # Add the tls entries to the beginning of the file, because entry order is important
+  echo "${PG_HBA_TLS_ENTRIES}$(cat $POSTGRES_PG_HBA_FILE)" > $POSTGRES_PG_HBA_FILE
+
+  service postgresql stop && service postgresql start
+
+  sudo -u postgres psql <<- "EOF"
+  create user go_auth_test with login password 'go_auth_test';
+  create database go_auth_test with owner go_auth_test;
+
+  create user go_auth_test_tls with login password 'go_auth_test_tls';
+  grant all privileges on database go_auth_test TO go_auth_test_tls;
+
+  create user go_auth_test_mutual_tls with login password 'go_auth_test_mutual_tls';
+  grant all privileges on database go_auth_test TO go_auth_test_mutual_tls;
+EOF
+
+  psql "user=go_auth_test password=go_auth_test host=127.0.0.1" <<- "EOF"
+  create table test_user(
+  id bigserial primary key,
+  username character varying (100) not null,
+  password_hash character varying (200) not null,
+  is_admin boolean not null);
+
+  create table test_acl(
+  id bigserial primary key,
+  test_user_id bigint not null references test_user on delete cascade,
+  topic character varying (200) not null,
+  rw int not null);
+EOF
+}
+
+function prepareAndStartMariaDb {
+  # Mariadb requires 'mysql' to be owner of the server key
+  mkdir -p /etc/ssl/private/mariadb
+  cp -r /test-files/certificates/db/server-key.pem /etc/ssl/private/mariadb/server-key.pem
+  chown mysql:mysql -R /etc/ssl/private/mariadb
+  usermod -aG ssl-cert mysql
+
+  cat > /etc/mysql/mariadb.conf.d/100-server-ssl-config.cnf <<- EOF
+[mysqld]
+ssl-ca=/test-files/certificates/db/fullchain-server.pem
+ssl-cert=/test-files/certificates/db/server.pem
+ssl-key=/etc/ssl/private/mariadb/server-key.pem
+EOF
+
+  service mariadb stop && service mariadb start
+
+  mysql <<- "EOF"
+  create database go_auth_test;
+
+  create user 'go_auth_test'@'localhost' identified by 'go_auth_test';
+  grant all privileges on go_auth_test.* to 'go_auth_test'@'localhost';
+
+  create user 'go_auth_test_tls'@'localhost' identified by 'go_auth_test_tls' REQUIRE SSL;
+  grant all privileges on go_auth_test.* to 'go_auth_test_tls'@'localhost';
+  create user 'go_auth_test_mutual_tls'@'localhost' identified by 'go_auth_test_mutual_tls' REQUIRE SUBJECT '/CN=Mosquitto Go Auth Test DB Client';
+  grant all privileges on go_auth_test.* to 'go_auth_test_mutual_tls'@'localhost';
+  flush privileges;
+EOF
+
+  mysql go_auth_test <<- "EOF"
+  create table test_user(
+  id mediumint not null auto_increment,
+  username varchar(100) not null,
+  password_hash varchar(200) not null,
+  is_admin boolean not null,
+  primary key(id)
+  );
+
+  create table test_acl(
+  id mediumint not null auto_increment,
+  test_user_id mediumint not null,
+  topic varchar(200) not null,
+  rw int not null,
+  primary key(id),
+  foreign key(test_user_id) references test_user(id)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE
+  );
+EOF
+}
+
+function prepareAndStartRedis() {
+  service redis-server start
+
+  mkdir /tmp/cluster-test
+  cd /tmp/cluster-test
+  mkdir 7000 7001 7002 7003 7004 7005
+  cat > 7000/redis.conf <<- EOF
 port 7000
 cluster-enabled yes
 cluster-config-file nodes.conf
@@ -19,65 +129,36 @@ cluster-node-timeout 5000
 appendonly yes
 EOF
 
-for i in 7001 7002 7003 7004 7005; do
-    sed s/7000/$i/ < 7000/redis.conf > $i/redis.conf
-done
+  for i in 7001 7002 7003 7004 7005; do
+      sed s/7000/$i/ < 7000/redis.conf > $i/redis.conf
+  done
 
-for i in 7000 7001 7002 7003 7004 7005; do
-    (cd $i; redis-server redis.conf > server.log 2>&1 &)
-done
+  for i in 7000 7001 7002 7003 7004 7005; do
+      (cd $i; redis-server redis.conf > server.log 2>&1 &)
+  done
 
-sudo -u postgres psql << "EOF"
-create user go_auth_test with login password 'go_auth_test';
-create database go_auth_test with owner go_auth_test;
-EOF
+  sleep 3
 
-psql "user=go_auth_test password=go_auth_test host=127.0.0.1" << "EOF"
+  yes yes | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 \
+      127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005 \
+      --cluster-replicas 1
+}
 
-create table test_user(
-id bigserial primary key,
-username character varying (100) not null,
-password_hash character varying (200) not null,
-is_admin boolean not null);
+checkIfContainer
 
-create table test_acl(
-id bigserial primary key,
-test_user_id bigint not null references test_user on delete cascade,
-topic character varying (200) not null,
-rw int not null);
-EOF
+# Copy certificates structure to container so we
+# don't overwrite anything
+mkdir -p /test-files/certificates
+cp -r /app/test-files/certificates/* /test-files/certificates
+# Remove all generated certificates because the generator does not delete already existing files
+rm -rf /test-files/certificates/*.pem && rm -rf /test-files/certificates/*.csr
+rm -rf /test-files/certificates/**/*.pem && rm -rf /test-files/certificates/**/*.csr
+/test-files/certificates/generate-all.sh
 
-
-mysql << "EOF"
-create user 'go_auth_test'@'localhost' identified by 'go_auth_test';
-create database go_auth_test;
-grant all privileges on go_auth_test.* to 'go_auth_test'@'localhost';
-EOF
-
-mysql go_auth_test << "EOF"
-create table test_user(
-id mediumint not null auto_increment,
-username varchar(100) not null,
-password_hash varchar(200) not null,
-is_admin boolean not null,
-primary key(id)
-);
-
-create table test_acl(
-id mediumint not null auto_increment,
-test_user_id mediumint not null,
-topic varchar(200) not null,
-rw int not null,
-primary key(id),
-foreign key(test_user_id) references test_user(id)
-ON DELETE CASCADE
-ON UPDATE CASCADE
-);
-EOF
-
-yes yes | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 \
-    127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005 \
-    --cluster-replicas 1
+prepareAndStartPostgres
+prepareAndStartMariaDb
+prepareAndStartRedis
+sudo -u mongodb mongod --config /etc/mongod.conf &
 
 cd /app
 export PATH=$PATH:/usr/local/go/bin

--- a/test-files/certificates/ca.json
+++ b/test-files/certificates/ca.json
@@ -1,0 +1,11 @@
+{
+  "CN": "Mosquitto Go Auth Test Root CA",
+  "CA": {
+    "expiry": "87600h",
+    "pathlen": 1
+  },
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  }
+}

--- a/test-files/certificates/ca.json
+++ b/test-files/certificates/ca.json
@@ -1,7 +1,7 @@
 {
   "CN": "Mosquitto Go Auth Test Root CA",
   "CA": {
-    "expiry": "87600h",
+    "expiry": "1h",
     "pathlen": 1
   },
   "key": {

--- a/test-files/certificates/db/ca.json
+++ b/test-files/certificates/db/ca.json
@@ -1,7 +1,7 @@
 {
   "CN": "Mosquitto Go Auth Test DB Intermediate CA",
   "CA": {
-    "expiry": "87600h",
+    "expiry": "1h",
     "pathlen": 0
   },
   "key": {

--- a/test-files/certificates/db/ca.json
+++ b/test-files/certificates/db/ca.json
@@ -1,0 +1,11 @@
+{
+  "CN": "Mosquitto Go Auth Test DB Intermediate CA",
+  "CA": {
+    "expiry": "87600h",
+    "pathlen": 0
+  },
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  }
+}

--- a/test-files/certificates/db/client.json
+++ b/test-files/certificates/db/client.json
@@ -1,0 +1,8 @@
+{
+  "CN": "Mosquitto Go Auth Test DB Client",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "hosts": [""]
+}

--- a/test-files/certificates/db/generate.sh
+++ b/test-files/certificates/db/generate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR
+
+cfssl genkey -initca ca.json | cfssljson -bare ca
+cfssl sign -ca ../ca.pem -ca-key ../ca-key.pem -config=profiles.json -profile=ca ca.csr | cfssljson -bare ca
+cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=server server.json | cfssljson -bare server
+cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=client client.json | cfssljson -bare client
+
+cat server.pem > fullchain-server.pem
+cat ca.pem >> fullchain-server.pem
+cat ../ca.pem >> fullchain-server.pem
+
+cat client.pem > fullchain-client.pem
+cat ca.pem >> fullchain-client.pem
+cat ../ca.pem >> fullchain-client.pem
+
+cd -

--- a/test-files/certificates/db/generate.sh
+++ b/test-files/certificates/db/generate.sh
@@ -7,6 +7,7 @@ cfssl genkey -initca ca.json | cfssljson -bare ca
 cfssl sign -ca ../ca.pem -ca-key ../ca-key.pem -config=profiles.json -profile=ca ca.csr | cfssljson -bare ca
 cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=server server.json | cfssljson -bare server
 cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=client client.json | cfssljson -bare client
+cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=client unauthorized-second-client.json | cfssljson -bare unauthorized-second-client
 
 cat server.pem > fullchain-server.pem
 cat ca.pem >> fullchain-server.pem

--- a/test-files/certificates/db/profiles.json
+++ b/test-files/certificates/db/profiles.json
@@ -1,16 +1,14 @@
 {
   "signing": {
     "default": {
-      "expiry": "87600h"
+      "expiry": "1h"
     },
     "profiles": {
       "ca": {
         "usages": [
-          "signing",
-          "cert sign",
-          "crl sign"
+          "cert sign"
         ],
-        "expiry": "87600h",
+        "expiry": "1h",
         "ca_constraint": {
           "is_ca": true,
           "max_path_len": 0,
@@ -19,21 +17,18 @@
       },
       "server": {
         "usages": [
-          "signing",
-          "digital signing",
           "key encipherment",
           "server auth"
         ],
-        "expiry": "87600h"
+        "expiry": "1h"
       },
       "client": {
         "usages": [
           "signing",
-          "digital signature",
           "key encipherment",
           "client auth"
         ],
-        "expiry": "87600h"
+        "expiry": "1h"
       }
     }
   }

--- a/test-files/certificates/db/profiles.json
+++ b/test-files/certificates/db/profiles.json
@@ -1,0 +1,40 @@
+{
+  "signing": {
+    "default": {
+      "expiry": "87600h"
+    },
+    "profiles": {
+      "ca": {
+        "usages": [
+          "signing",
+          "cert sign",
+          "crl sign"
+        ],
+        "expiry": "87600h",
+        "ca_constraint": {
+          "is_ca": true,
+          "max_path_len": 0,
+          "max_path_len_zero": true
+        }
+      },
+      "server": {
+        "usages": [
+          "signing",
+          "digital signing",
+          "key encipherment",
+          "server auth"
+        ],
+        "expiry": "87600h"
+      },
+      "client": {
+        "usages": [
+          "signing",
+          "digital signature",
+          "key encipherment",
+          "client auth"
+        ],
+        "expiry": "87600h"
+      }
+    }
+  }
+}

--- a/test-files/certificates/db/server.json
+++ b/test-files/certificates/db/server.json
@@ -1,0 +1,12 @@
+{
+  "CN": "Mosquitto Go Auth Test DB Server",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "hosts": [
+    "localhost",
+    "127.0.0.1",
+    "db.mosquitto-go-auth.invalid"
+  ]
+}

--- a/test-files/certificates/db/unauthorized-second-client.json
+++ b/test-files/certificates/db/unauthorized-second-client.json
@@ -1,0 +1,8 @@
+{
+  "CN": "Mosquitto Go Auth Test DB Second Client",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "hosts": [""]
+}

--- a/test-files/certificates/generate-all.sh
+++ b/test-files/certificates/generate-all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR
+
+cfssl genkey -initca ca.json | cfssljson -bare ca
+
+# New subcommand so we don't mess up our last cd location
+bash -c "./db/generate.sh"
+bash -c "./grpc/generate.sh"
+
+cd -

--- a/test-files/certificates/grpc/ca.json
+++ b/test-files/certificates/grpc/ca.json
@@ -1,0 +1,11 @@
+{
+  "CN": "Mosquitto Go Auth Test gRPC Intermediate CA",
+  "CA": {
+    "expiry": "87600h",
+    "pathlen": 0
+  },
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  }
+}

--- a/test-files/certificates/grpc/ca.json
+++ b/test-files/certificates/grpc/ca.json
@@ -1,7 +1,7 @@
 {
   "CN": "Mosquitto Go Auth Test gRPC Intermediate CA",
   "CA": {
-    "expiry": "87600h",
+    "expiry": "1h",
     "pathlen": 0
   },
   "key": {

--- a/test-files/certificates/grpc/client.json
+++ b/test-files/certificates/grpc/client.json
@@ -1,0 +1,8 @@
+{
+  "CN": "Mosquitto Go Auth Test gRPC Client",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "hosts": [""]
+}

--- a/test-files/certificates/grpc/generate.sh
+++ b/test-files/certificates/grpc/generate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR
+
+cfssl genkey -initca ca.json | cfssljson -bare ca
+cfssl sign -ca ../ca.pem -ca-key ../ca-key.pem -config=profiles.json -profile=ca ca.csr | cfssljson -bare ca
+cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=server server.json | cfssljson -bare server
+cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=profiles.json -profile=client client.json | cfssljson -bare client
+
+cat server.pem > fullchain-server.pem
+cat ca.pem >> fullchain-server.pem
+cat ../ca.pem >> fullchain-server.pem
+
+cat client.pem > fullchain-client.pem
+cat ca.pem >> fullchain-client.pem
+cat ../ca.pem >> fullchain-client.pem
+
+cd -

--- a/test-files/certificates/grpc/profiles.json
+++ b/test-files/certificates/grpc/profiles.json
@@ -1,16 +1,14 @@
 {
   "signing": {
     "default": {
-      "expiry": "87600h"
+      "expiry": "1h"
     },
     "profiles": {
       "ca": {
         "usages": [
-          "signing",
-          "cert sign",
-          "crl sign"
+          "cert sign"
         ],
-        "expiry": "87600h",
+        "expiry": "1h",
         "ca_constraint": {
           "is_ca": true,
           "max_path_len": 0,
@@ -19,21 +17,18 @@
       },
       "server": {
         "usages": [
-          "signing",
-          "digital signing",
           "key encipherment",
           "server auth"
         ],
-        "expiry": "87600h"
+        "expiry": "1h"
       },
       "client": {
         "usages": [
           "signing",
-          "digital signature",
           "key encipherment",
           "client auth"
         ],
-        "expiry": "87600h"
+        "expiry": "1h"
       }
     }
   }

--- a/test-files/certificates/grpc/profiles.json
+++ b/test-files/certificates/grpc/profiles.json
@@ -1,0 +1,40 @@
+{
+  "signing": {
+    "default": {
+      "expiry": "87600h"
+    },
+    "profiles": {
+      "ca": {
+        "usages": [
+          "signing",
+          "cert sign",
+          "crl sign"
+        ],
+        "expiry": "87600h",
+        "ca_constraint": {
+          "is_ca": true,
+          "max_path_len": 0,
+          "max_path_len_zero": true
+        }
+      },
+      "server": {
+        "usages": [
+          "signing",
+          "digital signing",
+          "key encipherment",
+          "server auth"
+        ],
+        "expiry": "87600h"
+      },
+      "client": {
+        "usages": [
+          "signing",
+          "digital signature",
+          "key encipherment",
+          "client auth"
+        ],
+        "expiry": "87600h"
+      }
+    }
+  }
+}

--- a/test-files/certificates/grpc/server.json
+++ b/test-files/certificates/grpc/server.json
@@ -1,0 +1,12 @@
+{
+  "CN": "Mosquitto Go Auth Test gRPC Server",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "hosts": [
+    "localhost",
+    "127.0.0.1",
+    "grpc.mosquitto-go-auth.invalid"
+  ]
+}


### PR DESCRIPTION
This PR makes it possible to create a secure connection to a postgresql, mariadb/mysql or grpc server without the requirement of a client certificate. Mutual TLS would be optional.