### PR TITLE
Postgres tls/sslmode "verify-full" as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,10 @@ Depending on the sslmode given, sslcert, sslkey and sslrootcert will be used. Op
 	require - Always SSL (skip verification)
 	verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)
 	verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)
+	
+From *mosquitto go auth* version 2.0.0 on `verify-full` will be the default sslmode instead of `disable`. You may have
+to disable transport layer security if the postgres database server doesn't support encryption and has a certificate
+signed by a trusted CA. 
 
 Queries work pretty much the same as in jpmen's plugin, so here's his discription (with some little changes) about them:
 

--- a/README.md
+++ b/README.md
@@ -594,22 +594,22 @@ The `postgres`  backend allows to specify queries for user, superuser and acl ch
 
 The following `auth_opt_` options are supported:
 
-| Option         		| default           |  Mandatory  | Meaning                  	 								|
-| --------------------- | ----------------- | :---------: | ----------------------------------------------------------- |
-| pg_host           	| 	 localhost      |             | hostname/address			 								|
-| pg_port           	| 		5432        |             | TCP port					 								|
-| pg_user           	|                   |     Y       | username					 								|
-| pg_password       	|                   |     Y       | password					 								|
-| pg_dbname         	|                   |     Y       | database name				 								|
-| pg_userquery      	|                   |     Y       | SQL for users				 								|
-| pg_superquery     	|                   |     N       | SQL for superusers			 								|
-| pg_aclquery       	|                   |     N       | SQL for ACLs				 								|
-| pg_sslmode        	|     disable       |     N       | SSL/TLS mode.				 								|
-| pg_sslcert        	|                   |     N       | SSL/TLS Client Cert.		 								|
-| pg_sslkey         	|                   |     N       | SSL/TLS Client Cert. Key	 								|
-| pg_sslrootcert    	|                   |     N       | SSL/TLS Root Cert			 								|
-| pg_connect_tries    	|        -1         |     N       | x < 0: try forever, x > 0: try x times						|
-| pg_max_life_time      |                   |     N       | connection max life time in seconds                         |
+| Option           | default     | Mandatory | Meaning                                |
+|------------------|-------------|:---------:|----------------------------------------|
+| pg_host          | localhost   |           | hostname/address                       |
+| pg_port          | 5432        |           | TCP port                               |
+| pg_user          |             |     Y     | username                               |
+| pg_password      |             |     Y     | password                               |
+| pg_dbname        |             |     Y     | database name                          |
+| pg_userquery     |             |     Y     | SQL for users                          |
+| pg_superquery    |             |     N     | SQL for superusers                     |
+| pg_aclquery      |             |     N     | SQL for ACLs                           |
+| pg_sslmode       | verify-full |     N     | SSL/TLS mode.                          |
+| pg_sslcert       |             |     N     | SSL/TLS Client Cert.                   |
+| pg_sslkey        |             |     N     | SSL/TLS Client Cert. Key               |
+| pg_sslrootcert   |             |     N     | SSL/TLS Root Cert                      |
+| pg_connect_tries | -1          |     N     | x < 0: try forever, x > 0: try x times |
+| pg_max_life_time |             |     N     | connection max life time in seconds    |
 
 Depending on the sslmode given, sslcert, sslkey and sslrootcert will be used. Options for sslmode are:
 

--- a/backends/jwt_test.go
+++ b/backends/jwt_test.go
@@ -254,6 +254,7 @@ func TestLocalPostgresJWT(t *testing.T) {
 		// Give necessary postgres options.
 		authOpts["jwt_pg_host"] = "localhost"
 		authOpts["jwt_pg_port"] = "5432"
+		authOpts["jwt_pg_sslmode"] = "disable"
 		authOpts["jwt_pg_dbname"] = "go_auth_test"
 		authOpts["jwt_pg_user"] = "go_auth_test"
 		authOpts["jwt_pg_password"] = "go_auth_test"
@@ -265,6 +266,7 @@ func TestLocalPostgresJWT(t *testing.T) {
 		pgAuthOpts := make(map[string]string)
 		pgAuthOpts["pg_host"] = "localhost"
 		pgAuthOpts["pg_port"] = "5432"
+		pgAuthOpts["pg_sslmode"] = "disable"
 		pgAuthOpts["pg_dbname"] = "go_auth_test"
 		pgAuthOpts["pg_user"] = "go_auth_test"
 		pgAuthOpts["pg_password"] = "go_auth_test"

--- a/backends/postgres.go
+++ b/backends/postgres.go
@@ -47,7 +47,7 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 	var postgres = Postgres{
 		Host:           "localhost",
 		Port:           "5432",
-		SSLMode:        "disable",
+		SSLMode:        "verify-full",
 		SuperuserQuery: "",
 		AclQuery:       "",
 		hasher:         hasher,
@@ -105,7 +105,7 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 		}
 		postgres.SSLMode = sslmode
 	} else {
-		postgres.SSLMode = "disable"
+		postgres.SSLMode = "verify-full"
 	}
 
 	if sslCert, ok := authOpts["pg_sslcert"]; ok {
@@ -129,16 +129,16 @@ func NewPostgres(authOpts map[string]string, logLevel log.Level, hasher hashing.
 	connStr := fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s", postgres.User, postgres.Password, postgres.DBName, postgres.Host, postgres.Port)
 
 	switch postgres.SSLMode {
+	case "disable":
+		connStr = fmt.Sprintf("%s sslmode=disable", connStr)
 	case "require":
 		connStr = fmt.Sprintf("%s sslmode=require", connStr)
 	case "verify-ca":
 		connStr = fmt.Sprintf("%s sslmode=verify-ca", connStr)
 	case "verify-full":
-		connStr = fmt.Sprintf("%s sslmode=verify-full", connStr)
-	case "disable":
 		fallthrough
 	default:
-		connStr = fmt.Sprintf("%s sslmode=disable", connStr)
+		connStr = fmt.Sprintf("%s sslmode=verify-full", connStr)
 	}
 
 	if postgres.SSLRootCert != "" {

--- a/backends/postgres_test.go
+++ b/backends/postgres_test.go
@@ -24,6 +24,7 @@ func TestPostgres(t *testing.T) {
 	//Initialize Postgres with some test values (omit tls).
 	authOpts["pg_dbname"] = "go_auth_test"
 	authOpts["pg_user"] = "go_auth_test"
+	authOpts["pg_sslmode"] = "disable"
 	authOpts["pg_password"] = "go_auth_test"
 	authOpts["pg_userquery"] = "SELECT password_hash FROM test_user WHERE username = $1 limit 1"
 	authOpts["pg_superquery"] = "select count(*) from test_user where username = $1 and is_admin = true"
@@ -204,6 +205,7 @@ func TestPostgresTls(t *testing.T) {
 	authOpts := make(map[string]string)
 	authOpts["pg_host"] = "localhost"
 	authOpts["pg_port"] = "5432"
+	authOpts["pg_sslmode"] = "disable"
 	authOpts["pg_dbname"] = "go_auth_test"
 	authOpts["pg_user"] = "go_auth_test_tls"
 	authOpts["pg_password"] = "go_auth_test_tls"


### PR DESCRIPTION
With this PR `verify-full` will be the default postgres sslmode instead of `disable`. A user then has to actively disable transport layer security. This improves security and hopefully awareness of users for it.