### PR TITLE
Fix docker commands in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,20 +1601,20 @@ and image with all required backend.
 To use it:
 ```
 docker build -t mosquitto-go-auth.test -f Dockerfile.runtest .
-docker run --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh
+docker run --rm -ti mosquitto-go-auth.test ./run-test-in-docker.sh
 ```
 
 Or using local source (avoid the need to rebuild image):
 ```
-docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh
+docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test ./run-test-in-docker.sh
 ```
 
 You may even specify the command to run after backends are started, which allow
 to run only some tests or even get a shell inside the containers:
 ```
-docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh make test-backends
+docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test ./run-test-in-docker.sh make test-backends
 
-docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test sh ./run-test-in-docker.sh bash
+docker run -v $(pwd):/app --rm -ti mosquitto-go-auth.test ./run-test-in-docker.sh bash
 ```
 
 ### License


### PR DESCRIPTION
`run-test-in-docker.sh` requires *bash* but was called with *sh*.