### PR TITLE
Automatically build binaries for Popular Linux archs

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl -o mosquitto.tgz https://mosquitto.org/files/source/mosquitto-${{ env.MOSQUITTO_VERSION }}.tar.gz
           tar -zxf mosquitto.tgz
-          mkdir -p output/linux-amd64 output/linux-arm64 output/linux-armv7 output/linux-armv6 output/linux-x86
+          mkdir -p output/linux-amd64 output/linux-arm64 output/linux-armv7 output/linux-armv6
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -32,7 +32,6 @@ jobs:
           zip -r linux-arm64.zip linux-arm64
           zip -r linux-armv7.zip linux-armv7
           zip -r linux-armv6.zip linux-armv6
-          zip -r linux-x86.zip linux-x86
       - name: Release files
         uses: softprops/action-gh-release@v1
         with:
@@ -41,4 +40,3 @@ jobs:
             output/linux-arm64.zip
             output/linux-armv6.zip
             output/linux-armv7.zip
-            output/linux-x86.zip

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,44 @@
+name: Build Linux Binaries
+
+on:
+  release:
+    types: [published]
+env:
+  MOSQUITTO_VERSION: 2.0.15
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: download mosquitto
+        run: |
+          curl -o mosquitto.tgz https://mosquitto.org/files/source/mosquitto-${{ env.MOSQUITTO_VERISON }}.tar.gz
+          tar -zxf mosquitto.tgz
+          mkdir -p output/linux-amd64 output/linux-arm64 output/linux-armv7 output/linux-armv6 output/linux-x86
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: mosquitto-go-auth
+      - name: run build
+        uses: addnab/docker-run-action@v3
+        with:
+          image: golang:latest
+          options: -e MOSQUITTO_VERSION=${{ MOSQUITTO_VERSION }} -v ${{ github.workspace }}:/usr/src -w /usr/src
+          run: |
+            /usr/src/mosquitto-go-auth/.github/workflows/scripts/build.sh
+      - name: zip
+        run: |
+          cd ${{ github.workspace }}/output
+          zip -r linux-amd64.zip linux-amd64
+          zip -r linux-arm64.zip linux-arm64
+          zip -r linux-armv7.zip linux-armv7
+          zip -r linux-armv6.zip linux-armv6
+          zip -r linux-x86.zip linux-x86
+      - name: Release files
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            output/linux-amd64.zip
+            output/linux-arm64.zip
+            output/linux-armv6.zip
+            output/linux-armv7.zip
+            output/linux-x86.zip

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: golang:latest
-          options: -e MOSQUITTO_VERSION=${{ MOSQUITTO_VERSION }} -v ${{ github.workspace }}:/usr/src -w /usr/src
+          options: -e MOSQUITTO_VERSION=${{ env.MOSQUITTO_VERSION }} -v ${{ github.workspace }}:/usr/src -w /usr/src
           run: |
             /usr/src/mosquitto-go-auth/.github/workflows/scripts/build.sh
       - name: zip

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: download mosquitto
         run: |
-          curl -o mosquitto.tgz https://mosquitto.org/files/source/mosquitto-${{ env.MOSQUITTO_VERISON }}.tar.gz
+          curl -o mosquitto.tgz https://mosquitto.org/files/source/mosquitto-${{ env.MOSQUITTO_VERSION }}.tar.gz
           tar -zxf mosquitto.tgz
           mkdir -p output/linux-amd64 output/linux-arm64 output/linux-armv7 output/linux-armv6 output/linux-x86
       - name: Checkout

--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-i386
-
+apt-get install -y gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi \
+  gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-i386 \
+  linux-libc-dev-x32-cross gcc-multilib
 cd /usr/src/mosquitto-$MOSQUITTO_VERSION/include
 cp *.h /usr/include
 cd /usr/src/mosquitto-go-auth

--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -14,7 +14,7 @@ cp go-auth.so pw /usr/src/output/linux-amd64
 make clean
 export CGO_ENABLED=1
 export GOARCH=arm64
-#export CC=aarch64-linux-gnu-gcc
+export CC=aarch64-linux-gnu-gcc
 make
 cp go-auth.so pw /usr/src/output/linux-arm64
 
@@ -23,7 +23,7 @@ make clean
 export CGO_ENABLED=1
 export GOARCH=arm
 export GOARM=7
-#export CC=arm-linux-gnueabi-gcc
+export CC=arm-linux-gnueabi-gcc
 make
 cp go-auth.so pw /usr/src/output/linux-armv7
 
@@ -32,6 +32,6 @@ make clean
 export CGO_ENABLED=1
 export GOARCH=arm
 export GOARM=6
-#export CC=arm-linux-gnueabi-gcc
+export CC=arm-linux-gnueabi-gcc
 make
 cp go-auth.so pw /usr/src/output/linux-armv6

--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi \
-  gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-i386 \
-  linux-libc-dev-x32-cross gcc-multilib
+apt-get install -y gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
 cd /usr/src/mosquitto-$MOSQUITTO_VERSION/include
 cp *.h /usr/include
 cd /usr/src/mosquitto-go-auth
@@ -16,7 +14,7 @@ cp go-auth.so pw /usr/src/output/linux-amd64
 make clean
 export CGO_ENABLED=1
 export GOARCH=arm64
-export CC=aarch64-linux-gnu-gcc
+#export CC=aarch64-linux-gnu-gcc
 make
 cp go-auth.so pw /usr/src/output/linux-arm64
 
@@ -25,7 +23,7 @@ make clean
 export CGO_ENABLED=1
 export GOARCH=arm
 export GOARM=7
-export CC=arm-linux-gnueabi-gcc
+#export CC=arm-linux-gnueabi-gcc
 make
 cp go-auth.so pw /usr/src/output/linux-armv7
 
@@ -34,16 +32,6 @@ make clean
 export CGO_ENABLED=1
 export GOARCH=arm
 export GOARM=6
-export CC=arm-linux-gnueabi-gcc
+#export CC=arm-linux-gnueabi-gcc
 make
 cp go-auth.so pw /usr/src/output/linux-armv6
-
-
-# build x86 Linux
-make clean
-export CGO_ENABLED=1
-export GOARCH=386
-export GOARM=
-export CC=gcc
-make
-cp go-auth.so pw /usr/src/output/linux-x86

--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-i386
+
+cd /usr/src/mosquitto-$MOSQUITTO_VERSION/include
+cp *.h /usr/include
+cd /usr/src/mosquitto-go-auth
+
+#build amd64 Linux
+make
+cp go-auth.so pw /usr/src/output/linux-amd64
+
+# build arm64 Linux
+make clean
+export CGO_ENABLED=1
+export GOARCH=arm64
+export CC=aarch64-linux-gnu-gcc
+make
+cp go-auth.so pw /usr/src/output/linux-arm64
+
+# build armv7 Linux
+make clean
+export CGO_ENABLED=1
+export GOARCH=arm
+export GOARM=7
+export CC=arm-linux-gnueabi-gcc
+make
+cp go-auth.so pw /usr/src/output/linux-armv7
+
+# build armv7 Linux
+make clean
+export CGO_ENABLED=1
+export GOARCH=arm
+export GOARM=6
+export CC=arm-linux-gnueabi-gcc
+make
+cp go-auth.so pw /usr/src/output/linux-armv6
+
+
+# build x86 Linux
+make clean
+export CGO_ENABLED=1
+export GOARCH=386
+export GOARM=
+export CC=gcc
+make
+cp go-auth.so pw /usr/src/output/linux-x86


### PR DESCRIPTION
This GH action uses the golang docker container to build the library for the following platforms:

- Linux/amd64
- Linux/arm64
- Linux/armv7
- Linux/armv6

Once built it adds them to the release as zip files

Links against version 2.0.15 of mosquitto but it's an env var at the top of the action so easily updated.

I couldn't get x86 to build nicely but less people are using that now and MacOS will take more work but I might see if I can get it going for a follow up PR.

fixes #162 

part of flowforge/installer#53