### PR TITLE
[issue-274]: Set gRPC backend name on initialization. Add mode to JWT backend name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1457,6 +1457,10 @@ message NameResponse {
 }
 ```
 
+Notice that `GetName` will only be used on client initialization in case you want to give your service a custom name,
+and on failure to request it the name will default to `gRPC`.
+The retrieved name will be used through out the lifecycle of the plugin until it's relaunched.
+
 #### Testing gRPC
 
 This backend has no special requirements as a gRPC server is mocked to test different scenarios.

--- a/backends/grpc.go
+++ b/backends/grpc.go
@@ -5,10 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
 	"io/ioutil"
 	"strconv"
 	"time"
+
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
@@ -27,6 +28,7 @@ type GRPC struct {
 	dialOptions      []grpc.DialOption
 	hostname         string
 	timeout          int
+	name             string
 }
 
 const defaultGRPCTimeoutMs = 500
@@ -139,11 +141,17 @@ func (o *GRPC) CheckAcl(username, topic, clientid string, acc int32) (bool, erro
 
 // GetName gets the gRPC backend's name.
 func (o *GRPC) GetName() string {
-	resp, err := o.client.GetName(context.Background(), &empty.Empty{})
-	if err != nil {
-		return "grpc get name error"
+	if len(o.name) == 0 {
+		resp, err := o.client.GetName(context.Background(), &empty.Empty{})
+
+		if err != nil {
+			o.name = "gRPC"
+		} else {
+			o.name = resp.Name
+		}
 	}
-	return resp.Name
+
+	return o.name
 }
 
 // Halt signals the gRPC backend that mosquitto is halting.

--- a/backends/grpc_test.go
+++ b/backends/grpc_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
+	"net"
+	"testing"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	gs "github.com/iegomez/mosquitto-go-auth/grpc"
 	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io/ioutil"
-	"net"
-	"testing"
 )
 
 const (
@@ -112,6 +113,9 @@ func TestGRPC(t *testing.T) {
 					auth, err := g.GetUser(grpcUsername, grpcPassword, grpcClientId)
 					So(err, ShouldNotBeNil)
 					c.So(auth, ShouldBeFalse)
+
+					name := g.GetName()
+					So(name, ShouldEqual, "gRPC")
 				})
 
 				Convey("it should work after the service comes back up", func(c C) {
@@ -124,6 +128,9 @@ func TestGRPC(t *testing.T) {
 					auth, err := g.GetUser(grpcUsername, grpcPassword, grpcClientId)
 					So(err, ShouldBeNil)
 					c.So(auth, ShouldBeTrue)
+
+					name := g.GetName()
+					So(name, ShouldEqual, "MyGRPCBackend")
 				})
 			})
 		})

--- a/backends/jwt.go
+++ b/backends/jwt.go
@@ -1,6 +1,8 @@
 package backends
 
 import (
+	"fmt"
+
 	jwtGo "github.com/golang-jwt/jwt"
 	"github.com/iegomez/mosquitto-go-auth/hashing"
 	"github.com/pkg/errors"
@@ -9,6 +11,7 @@ import (
 
 type JWT struct {
 	mode    string
+	name    string
 	checker jwtChecker
 }
 
@@ -90,32 +93,34 @@ func NewJWT(authOpts map[string]string, logLevel log.Level, hasher hashing.HashC
 		return nil, err
 	}
 
+	jwt.name = fmt.Sprintf("JWT %s", authOpts["jwt_mode"])
+
 	jwt.checker = checker
 
 	return jwt, nil
 }
 
-//GetUser authenticates a given user.
+// GetUser authenticates a given user.
 func (o *JWT) GetUser(token, password, clientid string) (bool, error) {
 	return o.checker.GetUser(token)
 }
 
-//GetSuperuser checks if the given user is a superuser.
+// GetSuperuser checks if the given user is a superuser.
 func (o *JWT) GetSuperuser(token string) (bool, error) {
 	return o.checker.GetSuperuser(token)
 }
 
-//CheckAcl checks user authorization.
+// CheckAcl checks user authorization.
 func (o *JWT) CheckAcl(token, topic, clientid string, acc int32) (bool, error) {
 	return o.checker.CheckAcl(token, topic, clientid, acc)
 }
 
-//GetName returns the backend's name
+// GetName returns the backend's name
 func (o *JWT) GetName() string {
-	return "JWT"
+	return o.name
 }
 
-//Halt closes any db connection.
+// Halt closes any db connection.
 func (o *JWT) Halt() {
 	o.checker.Halt()
 }

--- a/backends/jwt_test.go
+++ b/backends/jwt_test.go
@@ -909,6 +909,7 @@ func TestJWTJsonStatusOnlyServer(t *testing.T) {
 	Convey("Given correct options an http backend instance should be returned", t, func() {
 		hb, err := NewJWT(authOpts, log.DebugLevel, hashing.NewHasher(authOpts, ""), version)
 		So(err, ShouldBeNil)
+		So(hb.GetName(), ShouldEqual, "JWT remote")
 
 		Convey("Given correct password/username, get user should return true", func() {
 
@@ -1054,6 +1055,7 @@ func TestJWTJsonTextResponseServer(t *testing.T) {
 	Convey("Given correct options an http backend instance should be returned", t, func() {
 		hb, err := NewJWT(authOpts, log.DebugLevel, hashing.NewHasher(authOpts, ""), version)
 		So(err, ShouldBeNil)
+		So(hb.GetName(), ShouldEqual, "JWT remote")
 
 		Convey("Given correct password/username, get user should return true", func() {
 
@@ -1209,6 +1211,7 @@ func TestJWTFormJsonResponseServer(t *testing.T) {
 	Convey("Given correct options an http backend instance should be returned", t, func() {
 		hb, err := NewJWT(authOpts, log.DebugLevel, hashing.NewHasher(authOpts, ""), version)
 		So(err, ShouldBeNil)
+		So(hb.GetName(), ShouldEqual, "JWT remote")
 
 		Convey("Given correct password/username, get user should return true", func() {
 
@@ -1347,6 +1350,7 @@ func TestJWTFormStatusOnlyServer(t *testing.T) {
 	Convey("Given correct options an http backend instance should be returned", t, func() {
 		hb, err := NewJWT(authOpts, log.DebugLevel, hashing.NewHasher(authOpts, ""), version)
 		So(err, ShouldBeNil)
+		So(hb.GetName(), ShouldEqual, "JWT remote")
 
 		Convey("Given correct password/username, get user should return true", func() {
 


### PR DESCRIPTION
Fixes https://github.com/iegomez/mosquitto-go-auth/issues/274.