### PR TITLE
Fixed MongoDB insecureSkipVerify, Added MongoDB TLS certificate, ca, key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1275,8 +1275,11 @@ Options for `mongo` are the following:
 | auth_opt_mongo_users                 | users        |     N     | User collection                      |
 | auth_opt_mongo_acls                  | acls         |     N     | ACL collection                       |
 | auth_opt_mongo_disable_superuser     | true         |     N     | Disable query to check for superuser |
-| auth_opt_mongo_with_tls              | false        |     N     | Connect with TLS                     |
 | auth_opt_mongo_insecure_skip_verify  | false        |     N     | Verify server's certificate chain    |
+| auth_opt_mongo_tls                   | false        |     N     | Connect with TLS                     |
+| auth_opt_mongo_tlsca                 | ""           |     N     | TLS Certificate Authority (CA)       |
+| auth_opt_mongo_tlscert               | ""           |     N     | TLS Client Certificate               |
+| auth_opt_mongo_tlskey                | ""           |     N     | TLS Client Certificate Private Key   |
 
 
 If you experience any problem connecting to a replica set, please refer to [this issue](https://github.com/iegomez/mosquitto-go-auth/issues/32).

--- a/README.md
+++ b/README.md
@@ -1276,7 +1276,7 @@ Options for `mongo` are the following:
 | auth_opt_mongo_acls                  | acls         |     N     | ACL collection                       |
 | auth_opt_mongo_disable_superuser     | true         |     N     | Disable query to check for superuser |
 | auth_opt_mongo_insecure_skip_verify  | false        |     N     | Verify server's certificate chain    |
-| auth_opt_mongo_tls                   | false        |     N     | Connect with TLS                     |
+| auth_opt_mongo_with_tls              | false        |     N     | Connect with TLS                     |
 | auth_opt_mongo_tlsca                 | ""           |     N     | TLS Certificate Authority (CA)       |
 | auth_opt_mongo_tlscert               | ""           |     N     | TLS Client Certificate               |
 | auth_opt_mongo_tlskey                | ""           |     N     | TLS Client Certificate Private Key   |

--- a/backends/mongo.go
+++ b/backends/mongo.go
@@ -114,7 +114,7 @@ func NewMongo(authOpts map[string]string, logLevel log.Level, hasher hashing.Has
 
 	useTlsClientCertificate := false
 
-	if authOpts["mongo_tls"] == "true" {
+	if authOpts["mongo_with_tls"] == "true" {
 		m.withTLS = true
 	}
 
@@ -143,23 +143,28 @@ func NewMongo(authOpts map[string]string, logLevel log.Level, hasher hashing.Has
 	}
 
 	if m.withTLS {
-		log.Infof("mongo backend: tls enabled")
+		log.Info("mongo backend: tls enabled")
 		opts.TLSConfig = &tls.Config{
 			InsecureSkipVerify: m.insecureSkipVerify,
 		}
+
 		if useTlsClientCertificate {
 			caCert, err := os.ReadFile(m.TLSCa)
+
 			if err != nil {
 				log.Errorf("mongo backend: tls error: %s", err)
 			}
+
 			caCertPool := x509.NewCertPool()
 			if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-				log.Errorf("mongo backend: tls error: CA file must be in PEM format")
+				log.Error("mongo backend: tls error: CA file must be in PEM format")
 			}
+
 			cert, err := tls.LoadX509KeyPair(m.TLSCert, m.TLSKey)
 			if err != nil {
 				log.Errorf("mongo backend: tls error: %s", err)
 			}
+
 			opts.TLSConfig = &tls.Config{
 				RootCAs:            caCertPool,
 				Certificates:       []tls.Certificate{cert},


### PR DESCRIPTION
**1. Inconsistent TLS configuration:** To configure TLS for MongoDB, the readme.md said change the `auth_opt_mongo_with_tls` option to enable TLS, but in the backends/mongo.go file read `mongo_use_tls` which means `auth_opt_mongo_use_tls`

So I changed the configuration option key from `mongo_use_tls` to `mongo_tls` to be related to other TLS settings.

**2. insecureSkipVerify defined but never used:** It was defined in both doc (readme.md) and backends/mongo.go, but it was never called to be a part of connection configuration.

lead to the error below when trying to connect with self-signed SSL certificate:
```
time="2024-01-19T03:11:08Z" level=info msg="mongo backend: set authentication db to: mqtt"
time="2024-01-19T03:11:08Z" level=info msg="Backend registered: Mongo"
time="2024-01-19T03:11:08Z" level=info msg="registered acl checker: mongo"
time="2024-01-19T03:11:08Z" level=info msg="registered user checker: mongo"
time="2024-01-19T03:11:08Z" level=info msg="registered superuser checker: mongo"
time="2024-01-19T03:11:08Z" level=info msg="No cache set."
time="2024-01-19T03:16:02Z" level=debug msg="checking user C01103BDFF964C6B9004D5F33EB26208 with backend Mongo"
time="2024-01-19T03:16:32Z" level=debug msg="Mongo get user error: server selection error: server selection timeout, current topology: { Type: Unknown, Servers: [{ Addr: localhost:27017, Type: Unknown, Last error: x509: certificate is not valid for any names, but wanted to match localhost }, ] }"
time="2024-01-19T03:16:32Z" level=error msg="server selection error: server selection timeout, current topology: { Type: Unknown, Servers: [{ Addr: localhost:27017, Type: Unknown, Last error: x509: certificate is not valid for any names, but wanted to match localhost }, ] }"
```

**3. MongoDB Custom Certificates:**

From the document [MongoDB - Go Driver](https://www.mongodb.com/docs/drivers/go/current/fundamentals/connections/tls/#std-label-golang-enable-tls):

"To successfully initiate a TLS request, your application must present cryptographic certificates to prove its identity. Your application's certificates must be stored as PEM files to enable TLS when connecting."

So, I added the options to pass certificate paths to the module to complete a TLS connection through:
`auth_opt_mongo_tlsca` for TLS Certificate Authority (CA)
`auth_opt_mongo_tlscert` for TLS Client Certificate
`auth_opt_mongo_tlskey` for TLS Client Certificate Private Key
