### PR TITLE
if `auth_opt_jwt_skip_user_expiration` enabled, in case of receive bad token the code crashes. also README descriptions added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,11 +1000,14 @@ auth_opt_jwt_userquery select count(*) from test_user where username = $1 limit 
 Thus, the following specific JWT local options are supported:
 
 
-| Option                  | default   | Mandatory | Meaning                                                  |
-| ----------------------- | --------- | :-------: | -------------------------------------------------------- |
-| auth_opt_jwt_db         |  postgres |     N     | The DB backend to be used, either `postgres` or `mysql`  |
-| auth_opt_jwt_userquery  |           |     Y     | SQL query for users                                      |
-
+| Option                        | default   | Mandatory | Meaning                                                  |
+| ----------------------------- | --------- | :-------: | -------------------------------------------------------- |
+| auth_opt_jwt_db               |  postgres |     N     | The DB backend to be used, either `postgres` or `mysql`  |
+| auth_opt_jwt_userquery        |           |     Y     | SQL query for users                                      |
+| auth_opt_jwt_mysql_dbname     |           |     Y/N   | must set if auth_opt_jwt_db set is `mysql`               |
+| auth_opt_jwt_mysql_user       |           |     Y/N   | must set if auth_opt_jwt_db set is `mysql`               |
+| auth_opt_jwt_mysql_password   |           |     Y/N   | must set if auth_opt_jwt_db set is `mysql`               |
+| auth_opt_jwt_mysql_aclquery   |           |     Y/N   | ACL query must set if auth_opt_jwt_db set is `mysql`     |
 
 Notice that general `jwt_secret` is mandatory when using this mode.
 `jwt_userfield` is still optional and serves as a mean to extract the username from either the claim's `Subject` (`sub` field),
@@ -1022,7 +1025,7 @@ auth_opt_jwt_userquery select count(*) from "user" where username = $1 and is_ac
 For mysql:
 
 ```
-auth_opt_jwt_userquery select count(*) from "user" where username = ? and is_active = true limit 1
+auth_opt_jwt_mysql_aclquery select count(*) from "user" where username = ? and is_active = true limit 1
 ```
 
 *Important note:*

--- a/README.md
+++ b/README.md
@@ -1004,10 +1004,11 @@ auth_opt_jwt_userquery select count(*) from test_user where username = $1 limit 
 Thus, the following specific JWT local options are supported:
 
 
-| Option                        | default   | Mandatory | Meaning                                                  |
-| ----------------------------- | --------- | :-------: | -------------------------------------------------------- |
-| auth_opt_jwt_db               |  postgres |     N     | The DB backend to be used, either `postgres` or `mysql`  |
-| auth_opt_jwt_userquery        |           |     Y     | SQL query for users                                      |
+| Option                  | default   | Mandatory | Meaning                                                  |
+| ----------------------- | --------- | :-------: | -------------------------------------------------------- |
+| auth_opt_jwt_db         |  postgres |     N     | The DB backend to be used, either `postgres` or `mysql`  |
+| auth_opt_jwt_userquery  |           |     Y     | SQL query for users                                      |
+
 
 Notice that general `jwt_secret` is mandatory when using this mode.
 `jwt_userfield` is still optional and serves as a mean to extract the username from either the claim's `Subject` (`sub` field),

--- a/backends/jwt.go
+++ b/backends/jwt.go
@@ -132,19 +132,20 @@ func getJWTClaims(secret string, tokenStr string, skipExpiration bool) (*jwtGo.M
 	})
 
 	expirationError := false
-	if err != nil {					
+	if err != nil {
 		if v, ok := err.(*jwtGo.ValidationError); ok && v.Errors == jwtGo.ValidationErrorExpired {
-			log.Debugf("token expired: %s", err)
-			if skipExpiration {
-				expirationError = true
-			}else{
-				log.Debugf("jwt parse error: %s", err)
-				return nil, err	
+			log.Debugf("jwt token expired: %s", err)
+
+			if !skipExpiration {
+				return nil, err
 			}
-		}else{
+
+			expirationError = true
+		} else {
 			log.Debugf("jwt parse error: %s", err)
-			return nil, err	
-		}	
+
+			return nil, err
+		}
 	}
 
 	if !jwtToken.Valid && !expirationError {

--- a/backends/jwt.go
+++ b/backends/jwt.go
@@ -132,15 +132,19 @@ func getJWTClaims(secret string, tokenStr string, skipExpiration bool) (*jwtGo.M
 	})
 
 	expirationError := false
-	if err != nil {
-		if !skipExpiration {
-			log.Debugf("jwt parse error: %s", err)
-			return nil, err
-		}
-
+	if err != nil {					
 		if v, ok := err.(*jwtGo.ValidationError); ok && v.Errors == jwtGo.ValidationErrorExpired {
-			expirationError = true
-		}
+			log.Debugf("token expired: %s", err)
+			if skipExpiration {
+				expirationError = true
+			}else{
+				log.Debugf("jwt parse error: %s", err)
+				return nil, err	
+			}
+		}else{
+			log.Debugf("jwt parse error: %s", err)
+			return nil, err	
+		}	
 	}
 
 	if !jwtToken.Valid && !expirationError {


### PR DESCRIPTION
**issue 1**:  In README.md ACL in MySQL local mode configuration had some problems, 
**Workaround**:  I realized that it should be explained to the user what parts are required to use the mysql database in JWT mode. Also to use ACL In JWT mode, `auth_opt_jwt_mysql_aclquery` must be set with the correct query. this fields are:
`auth_opt_jwt_mysql_dbname` , `auth_opt_jwt_mysql_user` ,  `auth_opt_jwt_mysql_password` , `auth_opt_jwt_mysql_aclquery`   

**issue 2**:  When `auth_opt_jwt_skip_user_expiration` is enabled in config file and the wrong JWT token is sent by client to server (with a few or completely wrong segments), the code crashes.
**Workaround**:  modify the code structure by moving the checking of token expiration conditions.