### PR TITLE
Skip Postgres TLS tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ without-vcs:
 
 test:
 	cd plugin && make
-	go test ./backends ./cache ./hashing -v -count=1 -skip 'TestPostgresTls|TestPostgresMutualTls'
+	go test ./backends ./cache ./hashing -v -count=1 -buildvcs=false
 	rm plugin/*.so
 
 test-backends:
@@ -34,6 +34,12 @@ test-cache:
 
 test-hashing:
 	go test ./hashing -v -failfast -count=1
+
+build-docker-test:
+	docker build -t mosquitto-go-auth.test -f Dockerfile.runtest .
+
+run-docker-test:
+	docker run --rm -ti mosquitto-go-auth.test ./run-test-in-docker.sh
 
 service:
 	@echo "Generating gRPC code from .proto files"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ without-vcs:
 
 test:
 	cd plugin && make
-	go test ./backends ./cache ./hashing -v -count=1
+	go test ./backends ./cache ./hashing -v -count=1 -skip 'TestPostgresTls|TestPostgresMutualTls'
 	rm plugin/*.so
 
 test-backends:

--- a/backends/postgres_test.go
+++ b/backends/postgres_test.go
@@ -202,6 +202,7 @@ func TestPostgres(t *testing.T) {
 }
 
 func TestPostgresTls(t *testing.T) {
+	t.Skip("skipping test postgres tls")
 	authOpts := make(map[string]string)
 	authOpts["pg_host"] = "localhost"
 	authOpts["pg_port"] = "5432"
@@ -239,6 +240,7 @@ func TestPostgresTls(t *testing.T) {
 }
 
 func TestPostgresMutualTls(t *testing.T) {
+	t.Skip("skipping test postgres mutual tls")
 	authOpts := make(map[string]string)
 	authOpts["pg_host"] = "localhost"
 	authOpts["pg_port"] = "5432"


### PR DESCRIPTION
PG TLS tests started failing some time ago and I haven't figured out why, so they'll be skipped until I fix them because they're causing noise on unrelated PRs.